### PR TITLE
release(v0.0.6): Atom 1.0 + structured validation + audit fixes + Pages-via-Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,17 @@ jobs:
       cname: doc.rssgen.co
 
   # ----------------------------------------------------------------------
-  # MSRV — the published `rust-version = "1.85.0"` floor must keep
+  # MSRV — the published `rust-version = "1.88.0"` floor must keep
   # building. Without this lane, transient dep updates can silently
   # push the effective MSRV without anyone noticing. Bumped from 1.79
-  # in v0.0.6 because `time-core 0.1.9` (transitive of `time 0.3.51`)
-  # ships in edition 2024 and won't build under Cargo < 1.85.
+  # in v0.0.6 because the effective floor through current crates.io is
+  # 1.88: `time 0.3.51` / `time-core 0.1.9` declare
+  # `rust-version = "1.88"`, the `icu_*` chain (transitives of
+  # `url`/`idna`) and `criterion 0.8.2` pull 1.86, and the lowest
+  # version that satisfies every transitive is 1.88.0.
   # ----------------------------------------------------------------------
   msrv:
-    name: MSRV (1.85.0)
+    name: MSRV (1.88.0)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -75,13 +78,13 @@ jobs:
           show-progress: false
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: '1.85.0'
+          toolchain: '1.88.0'
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: msrv
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: cargo check (--all-features, lib + tests)
-        run: cargo +1.85.0 check --workspace --all-features --tests --benches --examples
+        run: cargo +1.88.0 check --workspace --all-features --tests --benches --examples
 
   # ----------------------------------------------------------------------
   # Miri — nightly UB sanity sweep. Even with `forbid(unsafe_code)`,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
     uses: sebastienrousseau/pipelines/.github/workflows/rust-ci.yml@main
     with:
       rust-version: 'stable'
-      # Coverage disabled on this branch — tarpaulin crashes mid-run on
-      # the integration test binary (`cargo test --workspace --all-features`
-      # passes locally at 187/0, but tarpaulin's instrumented subprocess
-      # exits non-zero with "Test failed during run" before reporting,
-      # giving an unactionable 92.6% / "exit code 1" pair). Re-enable
-      # after a tarpaulin upgrade or after splitting property tests out
-      # of the coverage subprocess. Codecov badge will stay at the
-      # last main-branch value until then.
+      # Cross-OS matrix (macOS + Windows) runs in addition to the
+      # Linux check on every push and PR. Catches platform-specific
+      # path / line-ending / quick-xml encoding regressions.
+      run-cross-platform: true
+      # Coverage is handled by the dedicated `coverage` job below
+      # using cargo-llvm-cov rather than the shared workflow's
+      # tarpaulin path, which crashes mid-run on this codebase's
+      # integration test binary (see the v0.0.5 ci.yml comment).
       run-coverage: false
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -47,3 +47,114 @@ jobs:
       type: rust
       redirect-crate: rss-gen
       cname: doc.rssgen.co
+
+  # ----------------------------------------------------------------------
+  # MSRV — the published `rust-version = "1.79.0"` floor must keep
+  # building. Without this lane, transient dep updates can silently
+  # push the effective MSRV without anyone noticing.
+  # ----------------------------------------------------------------------
+  msrv:
+    name: MSRV (1.79.0)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: '0'
+      CARGO_NET_RETRY: '2'
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+      RUST_BACKTRACE: short
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          show-progress: false
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: '1.79.0'
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: msrv
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: cargo check (--all-features, lib + tests)
+        run: cargo +1.79.0 check --workspace --all-features --tests --benches --examples
+
+  # ----------------------------------------------------------------------
+  # Miri — nightly UB sanity sweep. Even with `forbid(unsafe_code)`,
+  # Miri catches UB introduced through proc-macro / derive output
+  # (thiserror, serde) and through dep upgrades. Runs `cargo miri
+  # test --lib` over the safe-only library surface; integration tests
+  # spawn subprocesses Miri can't trace, so they're excluded.
+  # ----------------------------------------------------------------------
+  miri:
+    name: Miri (nightly)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      MIRIFLAGS: '-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check'
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          show-progress: false
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: nightly
+          components: miri
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: miri
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: cargo miri test --lib
+        run: cargo +nightly miri test --lib --all-features
+
+  # ----------------------------------------------------------------------
+  # Coverage — cargo-llvm-cov. Uses the LLVM source-based coverage
+  # backend rather than tarpaulin (which crashed on this codebase's
+  # integration test binary in the v0.0.5 cycle). Posts to Codecov.
+  # ----------------------------------------------------------------------
+  coverage:
+    name: Coverage (llvm-cov)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: '0'
+      CARGO_NET_RETRY: '2'
+      RUST_BACKTRACE: short
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          show-progress: false
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: llvm-cov
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: taiki-e/install-action@1ed3272338f573e042a2e6bca3893aa19f43b47a # v2
+        with:
+          tool: cargo-llvm-cov
+      - name: cargo llvm-cov
+        run: |
+          cargo llvm-cov --workspace --all-features \
+            --lcov --output-path lcov.info \
+            --ignore-filename-regex '(tests/|examples/|benches/|fuzz/)'
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,14 @@ jobs:
       cname: doc.rssgen.co
 
   # ----------------------------------------------------------------------
-  # MSRV — the published `rust-version = "1.79.0"` floor must keep
+  # MSRV — the published `rust-version = "1.85.0"` floor must keep
   # building. Without this lane, transient dep updates can silently
-  # push the effective MSRV without anyone noticing.
+  # push the effective MSRV without anyone noticing. Bumped from 1.79
+  # in v0.0.6 because `time-core 0.1.9` (transitive of `time 0.3.51`)
+  # ships in edition 2024 and won't build under Cargo < 1.85.
   # ----------------------------------------------------------------------
   msrv:
-    name: MSRV (1.79.0)
+    name: MSRV (1.85.0)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -73,13 +75,13 @@ jobs:
           show-progress: false
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: '1.79.0'
+          toolchain: '1.85.0'
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: msrv
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: cargo check (--all-features, lib + tests)
-        run: cargo +1.79.0 check --workspace --all-features --tests --benches --examples
+        run: cargo +1.85.0 check --workspace --all-features --tests --benches --examples
 
   # ----------------------------------------------------------------------
   # Miri — nightly UB sanity sweep. Even with `forbid(unsafe_code)`,
@@ -96,7 +98,13 @@ jobs:
       contents: read
     env:
       CARGO_TERM_COLOR: always
-      MIRIFLAGS: '-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check'
+      # Strict-provenance is the real UB catcher we want here.
+      # `-Zmiri-symbolic-alignment-check` was previously enabled but
+      # produced false positives on `memchr`'s SSE2 aligned-load path
+      # (via `quick-xml`'s parser) — the runtime alignment is correct
+      # but Miri's symbolic checker can't prove it. Miri's own help
+      # text admits this flag is noisy, so we drop it.
+      MIRIFLAGS: '-Zmiri-strict-provenance'
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,18 @@ jobs:
 
   docs:
     if: github.ref == 'refs/heads/main'
+    # Publishes via actions/deploy-pages (the modern, workflow-driven
+    # GitHub Pages flow) — supersedes the legacy gh-pages branch push.
+    # The `cname` input is bundled into the upload-pages-artifact tarball
+    # so the custom domain stays bound across every deploy. The
+    # repository Pages source has been switched to `build_type=workflow`;
+    # the `gh-pages` branch is retired.
     uses: sebastienrousseau/pipelines/.github/workflows/docs.yml@main
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     with:
       type: rust
       redirect-crate: rss-gen
+      cname: doc.rssgen.co

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,69 @@
+name: Release
+
+# Drives the release flow via release-plz:
+#
+#  * On every push to main, opens (or updates) a "release PR" with
+#    the bumped version, the regenerated CHANGELOG, and the inferred
+#    git-cliff section.
+#  * When that PR merges, tags the new version, creates a GitHub
+#    release, and publishes to crates.io.
+#
+# Tokens required (set as repo secrets):
+#  * `CRATES_TOKEN` — crates.io API token with `publish-update` scope.
+#  * `RELEASE_PLZ_TOKEN` — fine-grained GitHub PAT with `contents: write`
+#    and `pull-requests: write`. Falls back to GITHUB_TOKEN if absent.
+
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  release-plz-release:
+    name: release-plz release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'sebastienrousseau' }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+      - name: Run release-plz release
+        uses: release-plz/action@4f8f49b9b09bf36e4ddec61e4a8a91bd3b71e90a # v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+
+  release-plz-pr:
+    name: release-plz release-PR
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'sebastienrousseau' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+      - name: Run release-plz release-pr
+        uses: release-plz/action@4f8f49b9b09bf36e4ddec61e4a8a91bd3b71e90a # v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,9 +9,11 @@ name: Release
 #    release, and publishes to crates.io.
 #
 # Tokens required (set as repo secrets):
-#  * `CRATES_TOKEN` — crates.io API token with `publish-update` scope.
+#  * `CARGO_API_TOKEN` — crates.io API token with `publish-update` scope.
 #  * `RELEASE_PLZ_TOKEN` — fine-grained GitHub PAT with `contents: write`
-#    and `pull-requests: write`. Falls back to GITHUB_TOKEN if absent.
+#    and `pull-requests: write`. Falls back to GITHUB_TOKEN if absent
+#    (but note: PRs opened by GITHUB_TOKEN don't trigger CI on the
+#    release PR, so the PAT is strongly preferred).
 
 on:
   push:
@@ -40,7 +42,7 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_API_TOKEN }}
 
   release-plz-pr:
     name: release-plz release-PR
@@ -66,4 +68,4 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_API_TOKEN }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,69 @@
+name: SBOM
+
+# Generates a CycloneDX SBOM (Software Bill of Materials) for every
+# push to main and every tagged release. CycloneDX is the
+# OWASP-stewarded format that procurement teams ask for; the JSON
+# artifact is attached to releases for downstream supply-chain
+# verification.
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  cyclonedx:
+    name: CycloneDX SBOM
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write   # attach SBOM to releases
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          show-progress: false
+
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: sbom
+          save-if: false
+
+      - uses: taiki-e/install-action@1ed3272338f573e042a2e6bca3893aa19f43b47a # v2
+        with:
+          tool: cargo-cyclonedx
+
+      - name: Generate CycloneDX SBOM (JSON)
+        run: |
+          cargo cyclonedx --format json --all
+          mv rss-gen.cdx.json rss-gen.sbom.cdx.json || true
+
+      - name: Generate CycloneDX SBOM (XML)
+        run: |
+          cargo cyclonedx --format xml --all
+          mv rss-gen.cdx.xml rss-gen.sbom.cdx.xml || true
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom
+          path: |
+            rss-gen.sbom.cdx.json
+            rss-gen.sbom.cdx.xml
+          retention-days: 90
+
+      - name: Attach SBOM to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
+        with:
+          files: |
+            rss-gen.sbom.cdx.json
+            rss-gen.sbom.cdx.xml

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,49 @@
+name: OSSF Scorecard
+
+# Runs the OpenSSF Scorecard analysis on every push to main and on a
+# weekly cadence. Publishes the SARIF result to the Security tab and
+# uploads the scorecard JSON to the public Scorecard API so the
+# README badge resolves.
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '23 4 * * 1' # Mondays 04:23 UTC
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # to upload SARIF
+      id-token: write          # publish results to scorecard API
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to code-scanning dashboard
+        uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ISO 8601 parsing/formatting throughput; `0.3.51` is the build-fix
   for the macros-feature regression in `0.3.50`. No API changes
   affecting `rss-gen`.
+- **MSRV bumped from `1.79.0` to `1.85.0`.** `time-core 0.1.9` (a
+  transitive of `time 0.3.51`) ships in edition 2024 and won't
+  build under Cargo < 1.85. The 1.79 floor is no longer reachable
+  through current crates.io. CI now pins a dedicated MSRV lane to
+  the 1.85.0 floor so future dep updates can't silently push the
+  effective MSRV.
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,12 +84,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ISO 8601 parsing/formatting throughput; `0.3.51` is the build-fix
   for the macros-feature regression in `0.3.50`. No API changes
   affecting `rss-gen`.
-- **MSRV bumped from `1.79.0` to `1.85.0`.** `time-core 0.1.9` (a
-  transitive of `time 0.3.51`) ships in edition 2024 and won't
-  build under Cargo < 1.85. The 1.79 floor is no longer reachable
-  through current crates.io. CI now pins a dedicated MSRV lane to
-  the 1.85.0 floor so future dep updates can't silently push the
-  effective MSRV.
+- **MSRV bumped from `1.79.0` to `1.88.0`.** The effective floor
+  through current crates.io is 1.88: `time 0.3.51` and
+  `time-core 0.1.9` declare `rust-version = "1.88"`, the `icu_*`
+  chain (transitives of `url`/`idna`) and `criterion 0.8.2`
+  declare 1.86, and the lowest version that satisfies every
+  transitive is 1.88.0. CI now pins a dedicated MSRV lane to
+  this floor so future dep updates can't silently push the
+  effective MSRV without anyone noticing.
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,14 +39,71 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   whitespace, control characters, and empty strings are still
   rejected. Channel-level `link` retains its absolute-URL strictness
   as the spec requires.
+- **`RssFeedValidator::parse_date` is no longer GMT-only** (P0). The
+  pre-v0.0.6 implementation hard-required a literal `" GMT"` suffix
+  and rejected every spec-compliant feed produced outside of GMT
+  (`+0000`, `+0530`, `EST`, …). It now delegates to
+  `data::parse_date`, which accepts the full RFC 2822 timezone
+  grammar plus ISO 8601 — staying aligned with the channel-level
+  path used by `generate_rss`.
+- **`RssFeedValidator::validate_structure` no longer rejects empty
+  or relative item links** (P0). RSS 2.0 §5.7 explicitly allows
+  items to ship without a `<link>` so long as they carry a `<title>`
+  or `<description>`. The structural pass now skips empty item
+  links and delegates populated ones to `validate_link_field`,
+  matching `RssData::validate`. Pre-v0.0.6 the validator unconditionally
+  fed every item link to `Url::parse`, so feeds with description-only
+  items always failed.
 
 ### Changed
 
+- **`RssError::ValidationErrors` now carries `Vec<ValidationError>`
+  rather than `Vec<String>`.** Each entry exposes structured
+  `field` (a dotted path: `channel.title`, `item.0.link`, `feed.id`,
+  `entry.2.updated`) and `message` properties so callers (CI gates,
+  IDE integrations, JSON error responses) can dispatch on `field`
+  without parsing strings. `Display` writes the bare `message`, so
+  `e.to_string()` keeps the pre-v0.0.6 string format and
+  `errors.iter().any(|e| e.to_string() == "channel.title is missing")`
+  still works. `ValidationError` is now re-exported from the crate
+  root and prelude.
+- Date stack consolidated on `time`: dropped the `dtt` dependency
+  (was `0.0.x`, no SemVer stability) and removed `commons`
+  (euxis-commons) which was declared but never used in `src/`.
+  `parse_date` / `RssItem::pub_date_parsed` now return
+  `time::OffsetDateTime` directly rather than a `dtt::DateTime`
+  UTC sentinel — callers see the actual parsed offset.
+- Dropped the unused `serde_json` runtime dependency (it was never
+  imported under `src/`).
+- Removed the no-op `async = []` feature flag from `Cargo.toml`;
+  it gated zero `#[cfg]` code paths. A real Tokio / async-write
+  integration will return behind a properly wired flag in a
+  follow-up release.
 - Bumped `time` from `0.3.49` to `0.3.51` (supersedes Dependabot PR
   #33). `0.3.50` added the `Timestamp` type and improved RFC 2822 /
   ISO 8601 parsing/formatting throughput; `0.3.51` is the build-fix
   for the macros-feature regression in `0.3.50`. No API changes
   affecting `rss-gen`.
+
+### Performance
+
+- Stress benchmark added (`examples/stress_huge_feed`): 50 000-item
+  RSS 2.0 emit runs in ~15 ms (14 MiB output) and 50 000-entry
+  Atom 1.0 emit in ~114 ms (8.7 MiB output) on an M-series Mac in
+  release mode — both well under the < 1 s / generate budget.
+  `detect_feed_format` classifies a 23 MiB combined payload in
+  ~7 µs.
+
+### Tooling
+
+- Examples: `examples/example_atom.rs`,
+  `examples/example_detect.rs`, and
+  `examples/example_validation_errors.rs` cover Atom 1.0 emit
+  (multi-author, contributor, enclosure, HTML content), root-element
+  classification, and structured validation diagnostics.
+- Benchmarks: `benches/criterion.rs` extended with `Generate Atom`,
+  `Detect feed format`, and `Validate` groups in addition to the
+  existing `Generate RSS` / `Parse RSS` coverage.
 
 ## [0.0.5] - 2026-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to `rss-gen` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Atom 1.0 feed format support** (closes #24). A new `atom` module
+  provides `AtomFeed`, `AtomEntry`, `AtomPerson`, `AtomLink`, and the
+  `generate_atom` serializer, covering RFC 4287 required elements
+  (`id`, `title`, `updated` at both feed and entry level), feed-level
+  vs entry-level author resolution, media enclosures via
+  `<link rel="enclosure" type="..." length="...">`, plain-text and
+  HTML payloads for `<summary>` / `<content>`, multiple authors and
+  contributors, categories, `xml:lang`, icon/logo/rights/subtitle, and
+  RFC 3339 timestamp validation. Validation errors carry `feed.` and
+  `entry.<idx>.` context prefixes, matching the contextual error work
+  done for the RSS path in issue #34.
+- **Format auto-detection** via `detect_feed_format(&str) -> FeedFormat`
+  for dispatching between RSS (`<rss>` / `<rdf:RDF>`) and Atom inputs
+  without parsing the full document.
+- Re-exports added to the crate root and prelude: `generate_atom`,
+  `AtomFeed`, `AtomEntry`, `AtomLink`, `AtomPerson`, `AtomTextType`,
+  `FeedFormat`, `detect_feed_format`.
+
+### Fixed
+
+- **Validation error messages now carry context prefixes** (closes
+  #34). Channel-level errors are prefixed with `channel.` and
+  item-level errors with `item.`, replacing the previous bare
+  `Link is missing` / `Title is missing` strings that gave downstream
+  tooling no way to distinguish where the failure occurred.
+- **Relative item links are now accepted** per RSS 2.0 §5.7 via a new
+  `validate_link_field` helper. Absolute URLs, root-relative paths
+  (`/tags/`), and bare paths (`articles/foo.html`) all validate;
+  whitespace, control characters, and empty strings are still
+  rejected. Channel-level `link` retains its absolute-URL strictness
+  as the spec requires.
+
+### Changed
+
+- Bumped `time` from `0.3.49` to `0.3.51` (supersedes Dependabot PR
+  #33). `0.3.50` added the `Timestamp` type and improved RFC 2822 /
+  ISO 8601 parsing/formatting throughput; `0.3.51` is the build-fix
+  for the macros-feature regression in `0.3.50`. No API changes
+  affecting `rss-gen`.
+
 ## [0.0.5] - 2026-06-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1059,9 +1059,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,9 +219,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "derive_arbitrary"
@@ -243,20 +240,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "dtt"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300fa4cbe63b08446f74755c6cc002fb70e45bf50c32390f475d19b1ef23bc8e"
-dependencies = [
- "pastey",
- "serde",
- "serde_json",
- "thiserror",
- "time",
- "version_check",
 ]
 
 [[package]]
@@ -293,15 +276,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "euxis-commons"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc1cf9c4720703ea04d9eb4a191ac8e43b597805742e102fb7eaa4d9c3f5b27"
-dependencies = [
- "thiserror",
 ]
 
 [[package]]
@@ -593,12 +567,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pastey"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,8 +826,6 @@ version = "0.0.5"
 dependencies = [
  "arbitrary",
  "criterion",
- "dtt",
- "euxis-commons",
  "lazy_static",
  "log",
  "proptest",
@@ -867,7 +833,6 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "serde",
- "serde_json",
  "thiserror",
  "time",
  "tokio-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,12 @@ exclude = [
 
 [dependencies]
 # List of external crates used in this project
-dtt = "0.0"
 log = "0.4"
 quick-xml = { version = "0.40", features = ["serialize"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 thiserror = "2.0"
-time = "0.3"
+time = { version = "0.3", features = ["parsing", "formatting", "macros"] }
 url = "2.5"
-commons = { package = "euxis-commons", version = "0.0.2", default-features = false, features = ["error", "time"] }
 
 [build-dependencies]
 # Dependencies for build scripts
@@ -85,8 +82,10 @@ path = "src/lib.rs"                     # Path to the library entry point
 # -----------------------------------------------------------------------------
 # Features
 # -----------------------------------------------------------------------------
-[features]
-async = []
+# No optional features in v0.0.6. Async / Tokio integration was previously
+# advertised via a no-op `async = []` flag; the flag was removed because
+# nothing was `#[cfg]`-gated against it. It will return as a properly wired
+# `tokio` / `async-write` feature in a follow-up release.
 
 # -----------------------------------------------------------------------------
 # Benchmarking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "rss-gen"                            # The name of the library
 version = "0.0.5"                           # Current version of the crate
 authors = ["RSS Generator Contributors"]    # Library contributors
 edition = "2021"                            # Rust edition being used
-rust-version = "1.79.0"                     # Minimum supported Rust version (bumped for quick-xml 0.40)
+rust-version = "1.85.0"                     # Minimum supported Rust version. Bumped from 1.79.0 in v0.0.6: `time-core 0.1.9` (transitive of `time 0.3.51`) ships in edition 2024, which requires Rust 1.85+. The 1.79 floor is no longer reachable through current crates.io.
 license = "MIT OR Apache-2.0"               # Dual licensing strategy
 description = """
 A Rust library for generating, serializing, and deserializing RSS feeds for various RSS versions.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "rss-gen"                            # The name of the library
 version = "0.0.5"                           # Current version of the crate
 authors = ["RSS Generator Contributors"]    # Library contributors
 edition = "2021"                            # Rust edition being used
-rust-version = "1.85.0"                     # Minimum supported Rust version. Bumped from 1.79.0 in v0.0.6: `time-core 0.1.9` (transitive of `time 0.3.51`) ships in edition 2024, which requires Rust 1.85+. The 1.79 floor is no longer reachable through current crates.io.
+rust-version = "1.88.0"                     # Minimum supported Rust version. Bumped from 1.79.0 in v0.0.6: `time 0.3.51` / `time-core 0.1.9` declare `rust-version = "1.88"` and the `icu_*` chain (via `url`/`idna`) pulls 1.86. Effective floor through current crates.io is 1.88.
 license = "MIT OR Apache-2.0"               # Dual licensing strategy
 description = """
 A Rust library for generating, serializing, and deserializing RSS feeds for various RSS versions.

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ rss-gen = "0.0.6"
 
 | Surface | Minimum Supported Rust Version |
 | :--- | :--- |
-| Library | **1.85.0** (bumped from 1.79.0 in v0.0.6; `time-core 0.1.9` — transitive of `time 0.3.51` — ships in edition 2024 and won't build under Cargo < 1.85) |
+| Library | **1.88.0** (bumped from 1.79.0 in v0.0.6; `time 0.3.51` + `time-core 0.1.9` declare `rust-version = "1.88"`, the `icu_*` chain via `url`/`idna` pulls 1.86, and the effective floor through current crates.io is 1.88) |
 
-CI runs `stable` on every push, plus a dedicated MSRV lane that pins the 1.85.0 floor. Cross-platform matrix: Ubuntu + macOS + Windows.
+CI runs `stable` on every push, plus a dedicated MSRV lane that pins the 1.88.0 floor. Cross-platform matrix: Ubuntu + macOS + Windows.
 
 ### Build from source
 

--- a/README.md
+++ b/README.md
@@ -293,9 +293,13 @@ fn main() {
 
     match generate_rss(&feed) {
         Err(RssError::ValidationErrors(errors)) => {
-            assert!(errors.iter().any(|e| e == "channel.title is missing"));
-            assert!(errors.iter().any(|e| e == "channel.link is missing"));
-            assert!(errors.iter().any(|e| e == "channel.description is missing"));
+            // Each entry is a `ValidationError { field, message }` —
+            // dispatch programmatically on `field` rather than parsing
+            // strings; `Display` (`e.to_string()`) still gives the
+            // bare message for human-readable output.
+            assert!(errors.iter().any(|e| e.field == "channel.title"));
+            assert!(errors.iter().any(|e| e.field == "channel.link"));
+            assert!(errors.iter().any(|e| e.field == "channel.description"));
         }
         other => panic!("expected ValidationErrors, got {other:?}"),
     }

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ rss-gen = "0.0.6"
 
 | Surface | Minimum Supported Rust Version |
 | :--- | :--- |
-| Library | **1.79.0** (bumped from 1.68.0 in 0.0.5 to track `quick-xml 0.40`) |
+| Library | **1.85.0** (bumped from 1.79.0 in v0.0.6; `time-core 0.1.9` — transitive of `time 0.3.51` — ships in edition 2024 and won't build under Cargo < 1.85) |
 
-CI runs `stable` on every push. Cross-platform: macOS, Linux, Windows.
+CI runs `stable` on every push, plus a dedicated MSRV lane that pins the 1.85.0 floor. Cross-platform matrix: Ubuntu + macOS + Windows.
 
 ### Build from source
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@
   <a href="https://crates.io/crates/rss-gen"><img src="https://img.shields.io/crates/v/rss-gen.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/rss-gen"><img src="https://img.shields.io/badge/docs.rs-rss--gen-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/rssgen"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/rssgen?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/rssgen"><img src="https://img.shields.io/ossf-scorecard/github.com/sebastienrousseau/rssgen?style=for-the-badge&label=OpenSSF%20Scorecard&logo=openssf" alt="OpenSSF Scorecard" /></a>
   <a href="https://lib.rs/crates/rss-gen"><img src="https://img.shields.io/badge/lib.rs-rss--gen-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+</p>
+
+<p align="center">
+  <strong>50 000-item RSS feed in ~15 ms · Atom 1.0 in ~114 ms · format detection in 7 µs · 100 % rustdoc coverage · <code>#![forbid(unsafe_code)]</code></strong>
 </p>
 
 ---
@@ -442,10 +447,13 @@ Coordinated-disclosure contact and policy live in `CONTRIBUTING.md`.
 | Document | Covers |
 | :--- | :--- |
 | [`CHANGELOG.md`](CHANGELOG.md) | Per-release notes following Keep a Changelog 1.1.0. |
+| [`docs/MIGRATION-0.0.5-to-0.0.6.md`](docs/MIGRATION-0.0.5-to-0.0.6.md) | Mechanical migration guide for the v0.0.6 API breaks (`ValidationErrors` payload, `parse_date` return type, removed deps). |
+| [`docs/adr/`](docs/adr/) | Architecture Decision Records — structured `ValidationError`, `time`-only date stack, Atom as a sibling module. |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Setup, signed-commit policy, PR guidelines. |
+| [`.github/SECURITY.md`](.github/SECURITY.md) | Coordinated-disclosure policy. |
 | [`AUTHORS.md`](AUTHORS.md) | Contributor roll. |
-| [docs.rs/rss-gen](https://docs.rs/rss-gen) | Generated API reference for the published version. |
-| [`rssgen.co`](https://rssgen.co) | Long-form documentation, examples, and design notes. |
+| [docs.rs/rss-gen](https://docs.rs/rss-gen) | Generated API reference for the published version (100 % coverage). |
+| [`doc.rssgen.co`](https://doc.rssgen.co) | Live docs published from `main` via `actions/deploy-pages`. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,50 +1,372 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR MIT -->
+
 <p align="center">
-  <img src="https://kura.pro/rssgen/images/logos/rssgen.svg" alt="RSS Gen logo" width="128" />
+  <img src="https://cloudcdn.pro/rssgen/v1/logos/rssgen.svg" alt="RSS Gen logo" width="128" />
 </p>
 
-<h1 align="center">RSS Gen</h1>
+<h1 align="center">rss-gen</h1>
 
 <p align="center">
-  <strong>A Rust library for generating, serializing, and deserializing RSS feeds for various RSS versions.</strong>
+  An RSS and Atom 1.0 syndication library for Rust — generate, parse, and
+  validate feeds across every shipping RSS version plus Atom 1.0, with
+  <code>#![forbid(unsafe_code)]</code> and zero panics on the validated path.
 </p>
 
 <p align="center">
   <a href="https://github.com/sebastienrousseau/rssgen/actions"><img src="https://img.shields.io/github/actions/workflow/status/sebastienrousseau/rssgen/ci.yml?style=for-the-badge&logo=github" alt="Build" /></a>
   <a href="https://crates.io/crates/rss-gen"><img src="https://img.shields.io/crates/v/rss-gen.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
-  <a href="https://docs.rs/rss-gen"><img src="https://img.shields.io/badge/docs.rs-rss-gen-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
+  <a href="https://docs.rs/rss-gen"><img src="https://img.shields.io/badge/docs.rs-rss--gen-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/rssgen"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/rssgen?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
-  <a href="https://lib.rs/crates/rss-gen"><img src="https://img.shields.io/badge/lib.rs-v0.0.5-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+  <a href="https://lib.rs/crates/rss-gen"><img src="https://img.shields.io/badge/lib.rs-rss--gen-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
 </p>
+
+---
+
+## Contents
+
+- [Install](#install) — Cargo, MSRV, source
+- [Quick Start](#quick-start) — generate an RSS 2.0 feed in ten lines
+- [Library Usage](#library-usage)
+  - [RSS generation](#rss-generation)
+  - [Atom 1.0 generation](#atom-10-generation)
+  - [Parsing existing feeds](#parsing-existing-feeds)
+  - [Format auto-detection](#format-auto-detection)
+  - [Validation diagnostics](#validation-diagnostics)
+  - [`quick_rss` helper](#quick_rss-helper)
+  - [Constants and limits](#constants-and-limits)
+- [Modules](#modules)
+- [Features](#features)
+- [Development](#development)
+- [Security](#security)
+- [Documentation](#documentation)
+- [License](#license)
 
 ---
 
 ## Install
 
+### As a Rust library
+
 ```bash
 cargo add rss-gen
 ```
 
-Or add to `Cargo.toml`:
+Or pin explicitly in `Cargo.toml`:
 
 ```toml
 [dependencies]
-rss-gen = "0.0.5"
+rss-gen = "0.0.6"
 ```
 
-You need [Rust](https://rustup.rs/) 1.79.0 or later. Works on macOS, Linux, and Windows.
+### MSRV
+
+| Surface | Minimum Supported Rust Version |
+| :--- | :--- |
+| Library | **1.79.0** (bumped from 1.68.0 in 0.0.5 to track `quick-xml 0.40`) |
+
+CI runs `stable` on every push. Cross-platform: macOS, Linux, Windows.
+
+### Build from source
+
+```bash
+git clone https://github.com/sebastienrousseau/rssgen.git
+cd rssgen
+cargo test --workspace --all-features    # full suite, ~200 tests
+```
 
 ---
 
-## Overview
+## Quick Start
 
-RSS Gen creates, serializes, and deserializes syndication feeds in RSS
-and Atom 1.0.
+```rust
+use rss_gen::{generate_rss, RssData, RssItem, RssVersion};
 
-- **Feed generation** with a builder API
-- **XML serialization** to valid RSS or Atom 1.0 output
-- **Deserialization** of existing RSS feeds into Rust structs
-- **Multi-version support** — RSS 0.90 through 2.0 and Atom 1.0
-- **Format auto-detection** for dispatching between RSS and Atom inputs
+fn main() -> Result<(), rss_gen::RssError> {
+    // Construct an RSS 2.0 channel via the builder API.
+    let mut feed = RssData::new(Some(RssVersion::RSS2_0))
+        .title("My Rust Blog")
+        .link("https://example.com")
+        .description("A blog about Rust");
+
+    // Items are appended in the order they should appear.
+    feed.add_item(
+        RssItem::new()
+            .title("Hello, world")
+            .link("https://example.com/hello")
+            .description("First post")
+            .guid("https://example.com/hello"),
+    );
+
+    let xml = generate_rss(&feed)?;
+    assert!(xml.contains("<rss version=\"2.0\""));
+    assert!(xml.contains("<title>My Rust Blog</title>"));
+    Ok(())
+}
+```
+
+---
+
+## Library Usage
+
+### RSS generation
+
+`rss-gen` covers every shipping RSS version. Pick the wire format via
+`RssVersion`; the builder is the same for all of them.
+
+```rust
+use rss_gen::{generate_rss, RssData, RssItem, RssVersion};
+
+fn main() -> Result<(), rss_gen::RssError> {
+    let mut feed = RssData::new(Some(RssVersion::RSS2_0))
+        .title("Engineering")
+        .link("https://example.com")
+        .description("Posts from the engineering team")
+        .language("en-GB")
+        .pub_date("Sat, 27 Jun 2026 00:00:00 GMT")
+        .generator("rss-gen")
+        // `atom_link` advertises the canonical feed URL via the
+        // `<atom:link rel="self">` element on the channel.
+        .atom_link("https://example.com/feed.xml");
+
+    feed.add_item(
+        RssItem::new()
+            .title("Release notes")
+            .link("https://example.com/release")
+            .description("What shipped this week")
+            .guid("https://example.com/release")
+            .pub_date("Sat, 27 Jun 2026 00:00:00 GMT")
+            .author("editor@example.com"),
+    );
+
+    let xml = generate_rss(&feed)?;
+    // The emitted document is well-formed XML and includes the
+    // standard atom:self link required by most feed readers.
+    assert!(xml.contains(r#"<atom:link href="https://example.com/feed.xml""#));
+    Ok(())
+}
+```
+
+`RssVersion::{RSS0_90, RSS0_91, RSS0_92, RSS1_0, RSS2_0}` are all
+supported. RSS 1.0 emits the RDF wrapper (`<rdf:RDF>`); the others
+emit a `<rss>` root.
+
+### Atom 1.0 generation
+
+Atom is a sibling code path — independent types, the same ergonomics.
+RFC 4287 required elements (`id`, `title`, `updated`) are checked at
+serialise time; entries inherit feed-level authors when none are
+declared per-entry, per §4.1.1.
+
+```rust
+use rss_gen::{generate_atom, AtomEntry, AtomFeed};
+
+fn main() -> Result<(), rss_gen::RssError> {
+    let feed = AtomFeed::new()
+        .id("https://example.com/feed")
+        .title("My Atom Feed")
+        .updated("2026-06-27T00:00:00Z")
+        .author_name("Jane Doe")
+        // Convenience: emit `<link rel="self" href="...">`.
+        .self_link("https://example.com/atom.xml")
+        .add_entry(
+            AtomEntry::new()
+                .id("https://example.com/post-1")
+                .title("First Post")
+                .updated("2026-06-27T00:00:00Z")
+                // Plain-text summary; use `summary_html` for an
+                // explicit `type="html"` payload.
+                .summary("Hello, Atom"),
+        );
+
+    let xml = generate_atom(&feed)?;
+    assert!(xml.contains(r#"<feed xmlns="http://www.w3.org/2005/Atom">"#));
+    Ok(())
+}
+```
+
+Media enclosures (podcasts, attached video) follow Atom's typed-link
+model:
+
+```rust
+use rss_gen::{generate_atom, AtomEntry, AtomFeed};
+
+fn main() -> Result<(), rss_gen::RssError> {
+    let feed = AtomFeed::new()
+        .id("https://example.com/podcast")
+        .title("Pilot")
+        .updated("2026-06-27T00:00:00Z")
+        .author_name("Producer")
+        .add_entry(
+            AtomEntry::new()
+                .id("https://example.com/ep-1")
+                .title("Episode 1")
+                .updated("2026-06-27T00:00:00Z")
+                .summary("Pilot episode")
+                // Emits <link rel="enclosure" type="audio/mpeg" length="12345678" .../>
+                .add_enclosure(
+                    "https://example.com/ep-1.mp3",
+                    "audio/mpeg",
+                    12_345_678,
+                ),
+        );
+
+    let xml = generate_atom(&feed)?;
+    assert!(xml.contains(r#"rel="enclosure""#));
+    assert!(xml.contains(r#"type="audio/mpeg""#));
+    Ok(())
+}
+```
+
+### Parsing existing feeds
+
+`parse_rss` reads any supported RSS version into the same `RssData`
+struct used by the generator — round-tripping is symmetric.
+
+```rust
+use rss_gen::parse_rss;
+
+fn main() -> Result<(), rss_gen::RssError> {
+    let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Example</title>
+    <link>https://example.com</link>
+    <description>Sample feed</description>
+    <item>
+      <title>Post</title>
+      <link>https://example.com/post</link>
+      <description>Body</description>
+    </item>
+  </channel>
+</rss>"#;
+
+    let feed = parse_rss(xml, None)?;
+    assert_eq!(feed.title, "Example");
+    assert_eq!(feed.items.len(), 1);
+    assert_eq!(feed.items[0].title, "Post");
+    Ok(())
+}
+```
+
+### Format auto-detection
+
+When the caller does not know upfront whether the document is RSS or
+Atom, `detect_feed_format` peeks the root element and returns a
+classifier value. It does not parse the rest of the document.
+
+```rust
+use rss_gen::{detect_feed_format, FeedFormat};
+
+let rss_xml  = r#"<?xml version="1.0"?><rss version="2.0"><channel/></rss>"#;
+let atom_xml = r#"<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><id/></feed>"#;
+
+assert_eq!(detect_feed_format(rss_xml),  FeedFormat::Rss);
+assert_eq!(detect_feed_format(atom_xml), FeedFormat::Atom);
+```
+
+The classifier returns `FeedFormat::RssRdf` for RSS 1.0 (`<rdf:RDF>`)
+and `FeedFormat::Unknown` for documents that match neither root
+element — including hand-rolled `<feed>` documents that omit the Atom
+namespace declaration, so a misclassified payload does not silently
+flow into the Atom code path.
+
+### Validation diagnostics
+
+Every validation error is prefixed with the element that produced it,
+so downstream tools (static site generators, CI gates, IDE
+integrations) can point at the offending field rather than a bare
+"missing field" message.
+
+| Context | Example error string |
+| :--- | :--- |
+| RSS channel | `channel.title is missing`, `Invalid channel.link: …`, `Invalid channel.pub_date: …` |
+| RSS item | `item.title is missing`, `item.link is missing`, `Invalid item.link: …` |
+| Atom feed | `feed.id is missing`, `feed.updated is not a valid RFC 3339 timestamp: …` |
+| Atom entry | `entry.0.author is missing (and feed has no feed-level author)`, `entry.2.updated is missing` |
+
+```rust
+use rss_gen::{generate_rss, RssData, RssError};
+
+fn main() {
+    // Channel without a title, link, or description.
+    let feed = RssData::new(None);
+
+    match generate_rss(&feed) {
+        Err(RssError::ValidationErrors(errors)) => {
+            assert!(errors.iter().any(|e| e == "channel.title is missing"));
+            assert!(errors.iter().any(|e| e == "channel.link is missing"));
+            assert!(errors.iter().any(|e| e == "channel.description is missing"));
+        }
+        other => panic!("expected ValidationErrors, got {other:?}"),
+    }
+}
+```
+
+Item-level `link` follows RSS 2.0 §5.7 — absolute URLs, root-relative
+paths (`/tags/`), and bare paths (`articles/foo.html`) are all
+accepted; whitespace, control characters, and empty strings are
+rejected. Channel-level `link` retains absolute-URL strictness because
+the spec requires it.
+
+### `quick_rss` helper
+
+For one-shot generation of a minimal feed, `quick_rss` validates input
+bounds (length caps, URL scheme) and returns the serialised XML
+directly. Useful inside `build.rs`, snippet generators, and tests.
+
+```rust
+use rss_gen::quick_rss;
+
+fn main() -> Result<(), rss_gen::RssError> {
+    let xml = quick_rss(
+        "My Rust Blog",
+        "https://example.com",
+        "A blog about Rust",
+    )?;
+    assert!(xml.contains("<title>My Rust Blog</title>"));
+    assert!(xml.contains("<item>")); // an example item is included
+    Ok(())
+}
+```
+
+### Constants and limits
+
+`rss-gen` exposes its hard input bounds as `pub const` so callers can
+validate ahead of time rather than discover the limit at serialise
+time.
+
+| Constant | Value | Applies to |
+| :--- | ---: | :--- |
+| `MAX_TITLE_LENGTH` | 256 | `RssData::title`, `RssItem::title` |
+| `MAX_LINK_LENGTH` | 2 048 | `RssData::link`, `RssItem::link` |
+| `MAX_DESCRIPTION_LENGTH` | 100 000 | `RssData::description`, `RssItem::description` |
+| `MAX_GENERAL_LENGTH` | 1 024 | `RssData::category` and similar single-line fields |
+| `MAX_FEED_SIZE` | 1 048 576 (1 MiB) | Combined serialised feed size, enforced by `RssData::validate_size` |
+
+The `VERSION` constant resolves to the crate's `CARGO_PKG_VERSION` at
+compile time.
+
+```rust
+use rss_gen::{MAX_FEED_SIZE, VERSION};
+
+assert!(VERSION.starts_with(char::is_numeric));
+assert_eq!(MAX_FEED_SIZE, 1_048_576);
+```
+
+---
+
+## Modules
+
+| Module | Surface |
+| :--- | :--- |
+| `rss_gen::atom` | `AtomFeed`, `AtomEntry`, `AtomPerson`, `AtomLink`, `AtomTextType`, `FeedFormat`, `generate_atom`, `detect_feed_format`. |
+| `rss_gen::data` | `RssData`, `RssItem`, `RssVersion`, plus the `RssDataField` / `RssItemField` enums used by `set_field` / `set_item_field`. |
+| `rss_gen::error` | `RssError` (the crate-wide error enum) and the `Result<T> = std::result::Result<T, RssError>` alias. |
+| `rss_gen::generator` | `generate_rss`, `sanitize_content`, `write_element` — the RSS serialisation pipeline. |
+| `rss_gen::parser` | `parse_rss`, plus the `ElementHandler` trait for callers that need to plug in custom-element extraction. |
+| `rss_gen::validator` | Standalone validation helpers used by the generator and exposed for callers that want to validate before constructing. |
+| `rss_gen::macros` | Procedural shortcuts (`macro_set_rss_data_fields!`, `macro_write_element!`, …) for terse builder code. |
+| `rss_gen::prelude` | Re-exports the surface most callers need — `RssData`, `RssItem`, `RssVersion`, `AtomFeed`, `AtomEntry`, `generate_rss`, `generate_atom`, `parse_rss`, `quick_rss`, `detect_feed_format`, and the error types. |
 
 ---
 
@@ -52,81 +374,80 @@ and Atom 1.0.
 
 | | |
 | :--- | :--- |
-| **RSS generation** | Create RSS 2.0 feeds programmatically |
-| **Atom 1.0 generation** | Create Atom feeds with multi-author, enclosure, and HTML content |
-| **Serialization** | Serialize feeds to XML strings |
-| **Deserialization** | Parse existing RSS feeds into Rust structs |
-| **Multiple versions** | RSS 0.90, 0.91, 0.92, 1.0, 2.0, and Atom 1.0 |
-| **Format detection** | `detect_feed_format` peeks the root element |
-| **Validation** | Required-element validation with `channel.` / `item.` / `feed.` / `entry.<idx>.` context-prefixed errors |
-
----
-
-## Usage
-
-### RSS
-
-```rust
-use rss_gen::{generate_rss, RssData, RssVersion};
-
-let rss = RssData::new(Some(RssVersion::RSS2_0))
-    .title("My Blog")
-    .link("https://example.com")
-    .description("A blog about Rust");
-
-println!("{}", generate_rss(&rss).unwrap());
-```
-
-### Atom 1.0
-
-```rust
-use rss_gen::{generate_atom, AtomEntry, AtomFeed};
-
-let feed = AtomFeed::new()
-    .id("https://example.com/feed")
-    .title("My Blog")
-    .updated("2026-06-27T00:00:00Z")
-    .author_name("Jane Doe")
-    .self_link("https://example.com/atom.xml")
-    .add_entry(
-        AtomEntry::new()
-            .id("https://example.com/post-1")
-            .title("First Post")
-            .updated("2026-06-27T00:00:00Z")
-            .summary("Hello, Atom"),
-    );
-
-println!("{}", generate_atom(&feed).unwrap());
-```
-
-### Format detection
-
-```rust
-use rss_gen::{detect_feed_format, FeedFormat};
-
-let xml = r#"<?xml version="1.0"?>
-<feed xmlns="http://www.w3.org/2005/Atom"><id/></feed>"#;
-
-assert_eq!(detect_feed_format(xml), FeedFormat::Atom);
-```
+| **RSS generation** | Author RSS 0.90, 0.91, 0.92, 1.0, and 2.0 feeds through a single `RssData` builder. RSS 2.0 emits the standard `xmlns:atom` declaration so feed readers can recognise the `<atom:link rel="self">` element on the channel. |
+| **Atom 1.0 generation** | `AtomFeed` / `AtomEntry` cover RFC 4287 required elements, multi-author and contributor lists, categories, `xml:lang`, icon/logo/rights/subtitle, plain-text and HTML payloads for `<summary>` / `<content>`, and `<link rel="enclosure">` media attachments. |
+| **Parsing** | `parse_rss` reads RSS 0.9x / 1.0 / 2.0 into `RssData` and is symmetric with the generator — `parse_rss(generate_rss(x)?, None)?` round-trips structurally for valid inputs. |
+| **Format detection** | `detect_feed_format` classifies a document as `Rss`, `RssRdf`, `Atom`, or `Unknown` from the first start element, without parsing the body. |
+| **Validation** | Required-element checks at both feed and item / entry level, with `channel.`, `item.`, `feed.`, and `entry.<idx>.` context prefixes on every error message. RFC 3339 timestamp validation for Atom; relative item links for RSS 2.0 §5.7. |
+| **Sanitisation** | `sanitize_content` strips invalid XML control characters and is idempotent — round-tripping through it does not double-encode entities. |
+| **Robust XML backend** | `quick-xml` 0.40 with the `serialize` feature. Output is UTF-8, well-formed, and includes the `<?xml version="1.0" encoding="utf-8"?>` declaration. |
+| **Memory safety** | `#![forbid(unsafe_code)]` at the crate root; no FFI, no raw-pointer dereferences. |
+| **Lint posture** | `#![deny(clippy::all, clippy::cargo, clippy::pedantic)]` and `#![deny(missing_docs)]` — every public item is documented; every public surface passes pedantic Clippy. |
+| **Test posture** | Unit tests, integration tests, doctest coverage, property tests (`proptest`, `quickcheck`), and structure-aware fuzzers (`cargo fuzz`) for parsing, generation, date parsing, content sanitisation, and URL validation. |
 
 ---
 
 ## Development
 
 ```bash
-cargo build        # Build the project
-cargo test         # Run all tests
-cargo clippy       # Lint with Clippy
-cargo fmt          # Format with rustfmt
+cargo build                                  # build the library
+cargo test --workspace --all-features        # full test suite
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+cargo bench --bench benchmark                # Criterion harness
+cargo +nightly fuzz run fuzz_rss_parsing     # structure-aware fuzzing
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, signed commits, and PR guidelines.
+CI runs through a reusable workflow that gates Clippy, formatting,
+tests, `cargo audit`, `cargo deny`, dependency review, and `CodeQL` on
+every push and pull request. See [CONTRIBUTING.md](CONTRIBUTING.md)
+for signed-commit policy and PR guidelines.
 
 ---
 
-**THE ARCHITECT** \u1d2b [Sebastien Rousseau](https://sebastienrousseau.com)
-**THE ENGINE** \u1d5e [EUXIS](https://euxis.co) \u1d2b Enterprise Unified Execution Intelligence System
+## Security
+
+- **No `unsafe` blocks.** `#![forbid(unsafe_code)]` is enforced at the
+  crate root — no FFI to a C XML parser, no raw-pointer dereferences,
+  no `unsafe` blocks in the generator, parser, validator, or
+  sanitiser.
+- **Input bounds.** `MAX_TITLE_LENGTH`, `MAX_LINK_LENGTH`,
+  `MAX_DESCRIPTION_LENGTH`, `MAX_GENERAL_LENGTH`, and `MAX_FEED_SIZE`
+  cap every text dimension; `quick_rss` and `RssData::validate` /
+  `RssData::validate_size` enforce them. Set these before exposing
+  feed generation to untrusted input.
+- **Content sanitisation.** `sanitize_content` removes invalid XML
+  control characters (everything below `0x20` except `\n`, `\r`, `\t`)
+  and escapes `&`, `<`, `>`, `"`, and `'` so user-supplied content
+  cannot break feed well-formedness or smuggle injected markup.
+- **URL hygiene.** Channel-level `link` requires an absolute
+  `http` / `https` URL. Item-level `link` follows RSS 2.0 §5.7 and
+  permits relative paths, but rejects whitespace and control
+  characters that would otherwise break feed-reader parsers.
+- **Supply chain.** `cargo audit` and `cargo deny` run on every push
+  via the shared security workflow. Dependabot is wired for the
+  `minor-and-patch` group on `Cargo.toml`. `CodeQL` static analysis
+  runs on every push and pull request.
+
+Coordinated-disclosure contact and policy live in `CONTRIBUTING.md`.
+
+---
+
+## Documentation
+
+| Document | Covers |
+| :--- | :--- |
+| [`CHANGELOG.md`](CHANGELOG.md) | Per-release notes following Keep a Changelog 1.1.0. |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Setup, signed-commit policy, PR guidelines. |
+| [`AUTHORS.md`](AUTHORS.md) | Contributor roll. |
+| [docs.rs/rss-gen](https://docs.rs/rss-gen) | Generated API reference for the published version. |
+| [`rssgen.co`](https://rssgen.co) | Long-form documentation, examples, and design notes. |
+
+---
+
+**THE ARCHITECT** — [Sebastien Rousseau](https://sebastienrousseau.com)
+
+**THE ENGINE** — [EUXIS](https://euxis.co) — Enterprise Unified Execution Intelligence System
 
 ---
 
@@ -134,4 +455,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, signed commits, and PR guideli
 
 Dual-licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT](https://opensource.org/licenses/MIT), at your option.
 
-<p align="right"><a href="#rss-gen">Back to Top</a></p>
+<p align="right"><a href="#contents">Back to Top</a></p>

--- a/README.md
+++ b/README.md
@@ -37,12 +37,14 @@ You need [Rust](https://rustup.rs/) 1.79.0 or later. Works on macOS, Linux, and 
 
 ## Overview
 
-RSS Gen creates, serializes, and deserializes RSS feeds for multiple RSS versions.
+RSS Gen creates, serializes, and deserializes syndication feeds in RSS
+and Atom 1.0.
 
 - **Feed generation** with a builder API
-- **XML serialization** to valid RSS output
-- **Deserialization** of existing feeds into Rust structs
-- **Multi-version support** — RSS 0.90 through 2.0
+- **XML serialization** to valid RSS or Atom 1.0 output
+- **Deserialization** of existing RSS feeds into Rust structs
+- **Multi-version support** — RSS 0.90 through 2.0 and Atom 1.0
+- **Format auto-detection** for dispatching between RSS and Atom inputs
 
 ---
 
@@ -51,26 +53,61 @@ RSS Gen creates, serializes, and deserializes RSS feeds for multiple RSS version
 | | |
 | :--- | :--- |
 | **RSS generation** | Create RSS 2.0 feeds programmatically |
+| **Atom 1.0 generation** | Create Atom feeds with multi-author, enclosure, and HTML content |
 | **Serialization** | Serialize feeds to XML strings |
 | **Deserialization** | Parse existing RSS feeds into Rust structs |
-| **Multiple versions** | Support for RSS 0.90, 0.91, 0.92, 1.0, and 2.0 |
-| **Validation** | Validate feed structure and required elements |
+| **Multiple versions** | RSS 0.90, 0.91, 0.92, 1.0, 2.0, and Atom 1.0 |
+| **Format detection** | `detect_feed_format` peeks the root element |
+| **Validation** | Required-element validation with `channel.` / `item.` / `feed.` / `entry.<idx>.` context-prefixed errors |
 
 ---
 
 ## Usage
 
+### RSS
+
 ```rust
 use rss_gen::{generate_rss, RssData, RssVersion};
 
-fn main() {
-    let rss = RssData::new(Some(RssVersion::RSS2_0))
-        .title("My Blog")
-        .link("https://example.com")
-        .description("A blog about Rust");
+let rss = RssData::new(Some(RssVersion::RSS2_0))
+    .title("My Blog")
+    .link("https://example.com")
+    .description("A blog about Rust");
 
-    println!("{}", generate_rss(&rss).unwrap());
-}
+println!("{}", generate_rss(&rss).unwrap());
+```
+
+### Atom 1.0
+
+```rust
+use rss_gen::{generate_atom, AtomEntry, AtomFeed};
+
+let feed = AtomFeed::new()
+    .id("https://example.com/feed")
+    .title("My Blog")
+    .updated("2026-06-27T00:00:00Z")
+    .author_name("Jane Doe")
+    .self_link("https://example.com/atom.xml")
+    .add_entry(
+        AtomEntry::new()
+            .id("https://example.com/post-1")
+            .title("First Post")
+            .updated("2026-06-27T00:00:00Z")
+            .summary("Hello, Atom"),
+    );
+
+println!("{}", generate_atom(&feed).unwrap());
+```
+
+### Format detection
+
+```rust
+use rss_gen::{detect_feed_format, FeedFormat};
+
+let xml = r#"<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom"><id/></feed>"#;
+
+assert_eq!(detect_feed_format(xml), FeedFormat::Atom);
 ```
 
 ---

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD033 MD041 -->
-<img src="https://kura.pro/rssgen/images/logos/rssgen.svg"
+<img src="https://cloudcdn.pro/rssgen/v1/logos/rssgen.svg"
 alt="RSS Gen logo" height="66" align="right" />
 <!-- markdownlint-enable MD033 MD041 -->
 

--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -1,7 +1,10 @@
 #![allow(missing_docs)]
 use criterion::{criterion_group, criterion_main, Criterion};
 use lazy_static::lazy_static;
-use rss_gen::{generate_rss, parse_rss, RssData, RssItem, RssVersion};
+use rss_gen::{
+    detect_feed_format, generate_atom, generate_rss, parse_rss,
+    AtomEntry, AtomFeed, RssData, RssItem, RssVersion,
+};
 use std::hint::black_box;
 use std::time::Duration;
 
@@ -33,6 +36,26 @@ fn generate_large_rss_data(item_count: usize) -> RssData {
     rss_data
 }
 
+fn generate_large_atom_feed(entry_count: usize) -> AtomFeed {
+    let mut feed = AtomFeed::new()
+        .id("https://example.com/feed")
+        .title("Benchmark Atom Feed")
+        .updated("2026-06-28T00:00:00Z")
+        .author_name("rss-gen bench harness")
+        .self_link("https://example.com/atom.xml");
+
+    for i in 0..entry_count {
+        feed = feed.add_entry(
+            AtomEntry::new()
+                .id(format!("https://example.com/post-{i}"))
+                .title(format!("Entry {i}"))
+                .updated("2026-06-28T00:00:00Z")
+                .summary(format!("Summary for entry {i}")),
+        );
+    }
+    feed
+}
+
 lazy_static! {
     static ref SMALL_DATA: RssData = generate_large_rss_data(10);
     static ref MEDIUM_DATA: RssData = generate_large_rss_data(100);
@@ -40,6 +63,15 @@ lazy_static! {
     static ref SMALL_XML: String = generate_rss(&SMALL_DATA).unwrap();
     static ref MEDIUM_XML: String = generate_rss(&MEDIUM_DATA).unwrap();
     static ref LARGE_XML: String = generate_rss(&LARGE_DATA).unwrap();
+    static ref SMALL_ATOM: AtomFeed = generate_large_atom_feed(10);
+    static ref MEDIUM_ATOM: AtomFeed = generate_large_atom_feed(100);
+    static ref LARGE_ATOM: AtomFeed = generate_large_atom_feed(1000);
+    static ref SMALL_ATOM_XML: String =
+        generate_atom(&SMALL_ATOM).unwrap();
+    static ref MEDIUM_ATOM_XML: String =
+        generate_atom(&MEDIUM_ATOM).unwrap();
+    static ref LARGE_ATOM_XML: String =
+        generate_atom(&LARGE_ATOM).unwrap();
 }
 
 fn benchmark_generate_rss(c: &mut Criterion) {
@@ -78,5 +110,70 @@ fn benchmark_parse_rss(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, benchmark_generate_rss, benchmark_parse_rss);
+fn benchmark_generate_atom(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Generate Atom 1.0");
+    group
+        .sample_size(100)
+        .warm_up_time(Duration::from_secs(3))
+        .measurement_time(Duration::from_secs(8));
+    group.bench_function("Small (10)", |b| {
+        b.iter(|| generate_atom(black_box(&*SMALL_ATOM)))
+    });
+    group.bench_function("Medium (100)", |b| {
+        b.iter(|| generate_atom(black_box(&*MEDIUM_ATOM)))
+    });
+    group.bench_function("Large (1000)", |b| {
+        b.iter(|| generate_atom(black_box(&*LARGE_ATOM)))
+    });
+    group.finish();
+}
+
+fn benchmark_detect_feed_format(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Detect feed format");
+    group
+        .sample_size(200)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(3));
+    group.bench_function("RSS (small)", |b| {
+        b.iter(|| detect_feed_format(black_box(&SMALL_XML)))
+    });
+    group.bench_function("RSS (large)", |b| {
+        b.iter(|| detect_feed_format(black_box(&LARGE_XML)))
+    });
+    group.bench_function("Atom (small)", |b| {
+        b.iter(|| detect_feed_format(black_box(&SMALL_ATOM_XML)))
+    });
+    group.bench_function("Atom (large)", |b| {
+        b.iter(|| detect_feed_format(black_box(&LARGE_ATOM_XML)))
+    });
+    group.finish();
+}
+
+fn benchmark_validate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Validate");
+    group
+        .sample_size(100)
+        .warm_up_time(Duration::from_secs(2))
+        .measurement_time(Duration::from_secs(4));
+    group.bench_function("RSS validate (1000 items)", |b| {
+        b.iter(|| {
+            let _ = black_box(LARGE_DATA.validate());
+        })
+    });
+    group.bench_function("Atom validate (1000 entries)", |b| {
+        b.iter(|| {
+            let _ = black_box(LARGE_ATOM.validate());
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    benchmark_generate_rss,
+    benchmark_parse_rss,
+    benchmark_generate_atom,
+    benchmark_detect_feed_format,
+    benchmark_validate,
+);
 criterion_main!(benches);

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,34 @@
+# Codecov config for rss-gen
+#
+# Both the patch and project gates are informational ("informational:
+# true"). They surface in the PR summary so reviewers see the number,
+# but they do NOT block merges. The CI gates that DO block (clippy,
+# fmt, tests, Miri, MSRV, cross-OS matrix, audit, cargo-deny, CodeQL)
+# live in .github/workflows/ci.yml.
+#
+# Coverage exclusions match the cargo-llvm-cov invocation in
+# .github/workflows/ci.yml so the two views agree.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 5%
+        informational: true
+
+ignore:
+  - "tests/**"
+  - "examples/**"
+  - "benches/**"
+  - "fuzz/**"
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false

--- a/docs/MIGRATION-0.0.5-to-0.0.6.md
+++ b/docs/MIGRATION-0.0.5-to-0.0.6.md
@@ -54,12 +54,14 @@ switch to `time::OffsetDateTime` accessors (`.year()`, `.month()`,
 
 Rationale: ADR-0002 (`docs/adr/0002-time-only-date-stack.md`).
 
-## 3. MSRV bumped from 1.79.0 to 1.85.0
+## 3. MSRV bumped from 1.79.0 to 1.88.0
 
-`time-core 0.1.9` (a transitive of `time 0.3.51`) ships in
-edition 2024 and won't build under Cargo < 1.85. The 1.79 floor is
-no longer reachable through current crates.io. Bump your CI's
-toolchain to `1.85.0` or `stable` before pulling v0.0.6.
+The effective floor through current crates.io is 1.88: `time 0.3.51`
+and `time-core 0.1.9` declare `rust-version = "1.88"`, the `icu_*`
+chain (transitives of `url`/`idna`) and `criterion 0.8.2` declare
+1.86, and the lowest version that satisfies every transitive is
+1.88.0. Bump your CI's toolchain to `1.88.0` or `stable` before
+pulling v0.0.6.
 
 ## 4. Removed dependencies and feature flag
 

--- a/docs/MIGRATION-0.0.5-to-0.0.6.md
+++ b/docs/MIGRATION-0.0.5-to-0.0.6.md
@@ -1,0 +1,92 @@
+# Migrating from rss-gen 0.0.5 to 0.0.6
+
+This is a short, mechanical migration guide. v0.0.6 introduces three
+deliberate API breaks at the `0.0.x` SemVer level. Every other
+change is additive.
+
+## 1. `RssError::ValidationErrors` — variant payload changed
+
+**Before (0.0.5):**
+
+```rust
+RssError::ValidationErrors(Vec<String>)
+```
+
+**After (0.0.6):**
+
+```rust
+RssError::ValidationErrors(Vec<ValidationError>)
+```
+
+`ValidationError { field, message }` — `field` is a dotted path
+(`channel.title`, `item.0.link`, `feed.id`, `entry.2.updated`),
+`message` is the human-readable text. `Display` writes the bare
+`message`, so `e.to_string()` matches the pre-v0.0.6 string.
+
+| Pre-v0.0.6 pattern | v0.0.6 equivalent |
+| :--- | :--- |
+| `errors.iter().any(\|e\| e == "channel.title is missing")` | `errors.iter().any(\|e\| e.field == "channel.title")` (preferred) |
+| Same, string-compatible | `errors.iter().any(\|e\| e.to_string() == "channel.title is missing")` |
+| `errors.iter().any(\|e\| e.contains("Invalid channel.link"))` | `errors.iter().any(\|e\| e.field == "channel.link" && e.message.contains("Invalid"))` |
+| `RssError::ValidationErrors(vec!["…".into()])` | `RssError::ValidationErrors(vec![ValidationError::new("channel.title", "channel.title is missing")])` |
+
+Rationale: ADR-0001 (`docs/adr/0001-structured-validation-errors.md`).
+
+## 2. `data::parse_date` / `RssItem::pub_date_parsed` — return type changed
+
+**Before (0.0.5):**
+
+```rust
+pub fn parse_date(date_str: &str) -> Result<dtt::datetime::DateTime>
+```
+
+**After (0.0.6):**
+
+```rust
+pub fn parse_date(date_str: &str) -> Result<time::OffsetDateTime>
+```
+
+The returned value now reflects the actual parsed offset rather than
+a hard-coded UTC sentinel. Callers that only checked `.is_ok()` are
+unaffected. Callers that read fields from the returned value need to
+switch to `time::OffsetDateTime` accessors (`.year()`, `.month()`,
+`.offset()`, …).
+
+Rationale: ADR-0002 (`docs/adr/0002-time-only-date-stack.md`).
+
+## 3. Removed dependencies and feature flag
+
+| Removed | Why | Replacement |
+| :--- | :--- | :--- |
+| `dtt` | Experimental 0.0.x, redundant with `time` | `time::OffsetDateTime` directly |
+| `commons` (euxis-commons) | Unused in `src/` | n/a |
+| `serde_json` | Unused in `src/` (no JSON Feed support yet) | n/a |
+| `async = []` feature | No `#[cfg]` paths gated on it | Real Tokio integration arrives in a follow-up |
+
+If your project depended on these crates transitively *through*
+`rss-gen` only (i.e. you weren't importing them yourself), no
+action is needed. If you were relying on them being in the
+dependency tree, declare them directly in your own `Cargo.toml`.
+
+## 4. New surface (no migration needed — purely additive)
+
+- `rss_gen::atom::{AtomFeed, AtomEntry, AtomPerson, AtomLink, AtomTextType, FeedFormat}`
+- `rss_gen::atom::generate_atom`
+- `rss_gen::atom::detect_feed_format`
+- `rss_gen::ValidationError` (re-exported from `error`)
+
+All re-exported from the crate root and `prelude`.
+
+## 5. Validation behaviour changes (no API change)
+
+- Item-level `link` now accepts relative URLs per RSS 2.0 §5.7
+  (absolute URLs, root-relative paths like `/tags/`, and bare paths
+  like `articles/foo.html`). Channel-level `link` is unchanged.
+- `RssFeedValidator::parse_date` no longer requires a literal `" GMT"`
+  suffix; any RFC 2822 timezone form is accepted, plus ISO 8601.
+- `RssFeedValidator::validate_structure` no longer errors on items
+  without a `<link>` (RSS 2.0 §5.7 explicitly allows
+  description-only items).
+
+If your test suite was asserting that the old GMT-only / link-required
+behaviour fired, those assertions need to be removed.

--- a/docs/MIGRATION-0.0.5-to-0.0.6.md
+++ b/docs/MIGRATION-0.0.5-to-0.0.6.md
@@ -54,7 +54,14 @@ switch to `time::OffsetDateTime` accessors (`.year()`, `.month()`,
 
 Rationale: ADR-0002 (`docs/adr/0002-time-only-date-stack.md`).
 
-## 3. Removed dependencies and feature flag
+## 3. MSRV bumped from 1.79.0 to 1.85.0
+
+`time-core 0.1.9` (a transitive of `time 0.3.51`) ships in
+edition 2024 and won't build under Cargo < 1.85. The 1.79 floor is
+no longer reachable through current crates.io. Bump your CI's
+toolchain to `1.85.0` or `stable` before pulling v0.0.6.
+
+## 4. Removed dependencies and feature flag
 
 | Removed | Why | Replacement |
 | :--- | :--- | :--- |
@@ -68,7 +75,7 @@ If your project depended on these crates transitively *through*
 action is needed. If you were relying on them being in the
 dependency tree, declare them directly in your own `Cargo.toml`.
 
-## 4. New surface (no migration needed — purely additive)
+## 5. New surface (no migration needed — purely additive)
 
 - `rss_gen::atom::{AtomFeed, AtomEntry, AtomPerson, AtomLink, AtomTextType, FeedFormat}`
 - `rss_gen::atom::generate_atom`
@@ -77,7 +84,7 @@ dependency tree, declare them directly in your own `Cargo.toml`.
 
 All re-exported from the crate root and `prelude`.
 
-## 5. Validation behaviour changes (no API change)
+## 6. Validation behaviour changes (no API change)
 
 - Item-level `link` now accepts relative URLs per RSS 2.0 §5.7
   (absolute URLs, root-relative paths like `/tags/`, and bare paths

--- a/docs/adr/0001-structured-validation-errors.md
+++ b/docs/adr/0001-structured-validation-errors.md
@@ -1,0 +1,67 @@
+# ADR-0001: Structured `ValidationError` payload
+
+**Status:** Accepted (v0.0.6)
+**Date:** 2026-06-28
+
+## Context
+
+Through v0.0.5 the crate emitted `RssError::ValidationErrors(Vec<String>)` —
+a flat list of human-readable strings. Downstream tooling
+(static-site generators, CI gates, IDE plugins) had to grep against
+those strings to surface field-level diagnostics. That coupling was
+fragile, and the strings themselves didn't distinguish channel- from
+item-level failures (issue #34: `staticdatagen` produced cryptic
+`Invalid link: …` errors that named neither the failing field nor
+the surrounding `RssData` instance).
+
+## Decision
+
+Change the variant payload to `Vec<ValidationError>`, where each
+`ValidationError` is
+
+```rust
+pub struct ValidationError {
+    pub field: String,    // dotted path, e.g. "channel.title", "item.0.link"
+    pub message: String,  // human-readable text, e.g. "channel.title is missing"
+}
+```
+
+`field` uses dotted-path notation
+(`channel.<name>` / `item.<idx>.<name>` for RSS; `feed.<name>` /
+`entry.<idx>.<name>` for Atom). `Display` writes the bare `message`,
+so `e.to_string()` keeps the pre-v0.0.6 string format and existing
+callers using `errors.iter().any(|e| e.to_string().contains("…"))`
+continue to compile and pass.
+
+## Alternatives considered
+
+1. **Add a parallel `validate_structured()` returning the new
+   shape, leaving `validate()` on `Vec<String>`.** Rejected as
+   long-term debt: every callsite would need to choose between two
+   APIs, and the string-based one would silently rot.
+2. **Use a richer error enum
+   (`MissingTitle`, `InvalidLink(String)`, …) instead of a struct.**
+   Rejected because the field-name space is open (custom XML
+   extensions, future spec additions). A `String` field keeps the
+   API forward-compatible without enum-variant churn.
+3. **Add a `code: &'static str` for typed dispatch.** Deferred —
+   the dotted path covers the majority case, and `code` can be
+   layered on later as a `#[non_exhaustive]` enum without breaking
+   anyone.
+
+## Consequences
+
+- **Breaking API change** at the `RssError::ValidationErrors`
+  variant — callers that pattern-matched on `Vec<String>` need to
+  migrate (see [`docs/MIGRATION-0.0.5-to-0.0.6.md`](../MIGRATION-0.0.5-to-0.0.6.md)).
+  Accepted: the crate is `0.0.x` and the new shape is the
+  right long-term primitive.
+- Downstream tools can now dispatch on `e.field == "channel.title"`
+  rather than string parsing.
+- `Display` is a thin wrapper over `message`, so the human-readable
+  output is unchanged.
+
+## References
+
+- Issue [#34](https://github.com/sebastienrousseau/rssgen/issues/34)
+- v0.0.6 audit, P2 "RssError::ValidationErrors flattens structure"

--- a/docs/adr/0002-time-only-date-stack.md
+++ b/docs/adr/0002-time-only-date-stack.md
@@ -1,0 +1,63 @@
+# ADR-0002: Date stack consolidated on `time` (drop `dtt`)
+
+**Status:** Accepted (v0.0.6)
+**Date:** 2026-06-28
+
+## Context
+
+Through v0.0.5 the crate depended on three crates for date handling:
+
+- `dtt = "0.0"` — author-maintained custom datetime crate.
+- `time = "0.3"` — the de-facto Rust datetime crate, already pulled
+  in for RFC 2822 / ISO 8601 parsing.
+- `commons = { package = "euxis-commons", … }` — a workspace-shared
+  helper crate that internally pulled in the `time` feature set.
+
+The three crates were redundant. `dtt 0.0.x` has no SemVer stability
+guarantee (every 0.0.x release can break consumers without warning),
+and the existing `parse_date` immediately discarded `time`'s parsed
+`OffsetDateTime` by constructing a sentinel UTC `dtt::DateTime` —
+callers never saw the actual parsed offset. Meanwhile
+`euxis-commons` was declared in `[dependencies]` but `grep -r commons::
+src/` returned zero hits.
+
+## Decision
+
+- Drop `dtt` entirely. `parse_date` and
+  `RssItem::pub_date_parsed` return `time::OffsetDateTime` directly.
+- Drop `commons` entirely (unused).
+- Declare `time` with explicit
+  `features = ["parsing", "formatting", "macros"]`. Previously the
+  parsing feature was pulled in transitively via `commons`; with
+  `commons` gone, we need to be explicit so the build doesn't break
+  on the next dep tree shake.
+
+## Alternatives considered
+
+1. **Pin `dtt` to the latest 0.0.x and live with it.** Rejected:
+   pre-1.0 crates routinely break their callers, and the value
+   `dtt` was adding (a UTC sentinel return) was negative.
+2. **Wrap `time::OffsetDateTime` in a crate-internal newtype.**
+   Deferred: `OffsetDateTime` is already the right abstraction, and
+   wrapping it would force users to convert at the boundary for no
+   gain.
+3. **Add `chrono` as an alternate backend.** Rejected: `time` and
+   `chrono` cover overlapping ground and `time` is the lighter
+   dependency; doubling the surface is the wrong trade.
+
+## Consequences
+
+- **Breaking API change** on `parse_date` and
+  `RssItem::pub_date_parsed` return types (`dtt::DateTime` →
+  `time::OffsetDateTime`). Callers that only checked `.is_ok()` are
+  unaffected; callers that read fields out of the returned value
+  must migrate.
+- Compile-time and runtime closer to the metal — no
+  parse-then-discard-then-construct round-trip.
+- Dependency graph smaller (three crates dropped: `dtt`,
+  `euxis-commons`, and their transitives).
+
+## References
+
+- v0.0.6 audit, "Crate Redundancies in Date/Time Crates"
+- [`time` crate](https://crates.io/crates/time) feature matrix

--- a/docs/adr/0003-atom-as-sibling-module.md
+++ b/docs/adr/0003-atom-as-sibling-module.md
@@ -1,0 +1,70 @@
+# ADR-0003: Atom 1.0 as a sibling module, not an RSS subtype
+
+**Status:** Accepted (v0.0.6)
+**Date:** 2026-06-28
+
+## Context
+
+Issue #24 (P1) asked for Atom 1.0 support alongside RSS. Two
+structural options were on the table:
+
+1. **Unified data model.** Generalise `RssData` into a `Feed` struct
+   that can serialise to either RSS or Atom, with version-aware
+   field elision.
+2. **Sibling module.** Ship a new `atom` module with independent
+   `AtomFeed` / `AtomEntry` types and a separate `generate_atom`
+   serialiser, leaving the RSS surface untouched.
+
+## Decision
+
+Ship the **sibling module**. `AtomFeed` / `AtomEntry` live in
+`src/atom.rs` and mirror the `RssData` / `RssItem` ergonomic style
+(chained `.title()`, `.link()`, …) without sharing concrete types.
+`generate_atom(&AtomFeed)` is a top-level function exported from the
+crate root and the `prelude`. A separate
+`detect_feed_format(&str) -> FeedFormat` helper handles dispatching
+between the two paths on input.
+
+## Alternatives considered
+
+The unified-model approach was rejected because RSS and Atom diverge
+in ways the data model would have to flatten:
+
+- **Author shape.** RSS uses a single `<author>` (often an email
+  address); Atom requires a structured `<author>` with `name`,
+  optional `email`, optional `uri`, and supports multiple authors at
+  feed and entry level.
+- **Date formats.** RSS uses RFC 822 / RFC 2822; Atom uses
+  RFC 3339. Unifying these would force a parse-and-reformat round
+  trip on every serialise.
+- **Content modelling.** Atom distinguishes `<summary>` from
+  `<content>` and carries a `type` attribute (`text` / `html` /
+  `xhtml`). RSS has only `<description>`.
+- **Identifier semantics.** Atom requires a permanent `<id>` on the
+  feed (RFC 4287 §4.2.6) — RSS has no equivalent at the channel
+  level.
+
+A unified model would carry every concept from both formats and
+expose them as `Option<…>`, leaving consumers to figure out which
+fields apply to which output. That trades a one-time learning cost
+(two builder APIs) for a permanent ergonomic cost (every field is
+optional, every serialise risks dropping data silently).
+
+## Consequences
+
+- **API surface doubled** at the builder level — but each builder
+  is internally simpler than a unified one would be, and the
+  prelude re-exports both so most callers see a single import.
+- **Parser is RSS-only for now.** Atom parsing was deferred from
+  the v0.0.6 scope. `detect_feed_format` lets callers reject
+  unsupported inputs explicitly until the Atom parser ships.
+- **Validation messages are consistent across both paths** — the
+  contextual `feed.id` / `entry.<idx>.author` prefixes used by
+  `AtomFeed::validate` mirror the `channel.title` / `item.<idx>.link`
+  prefixes used by `RssData::validate` (ADR-0001).
+
+## References
+
+- Issue [#24](https://github.com/sebastienrousseau/rssgen/issues/24)
+- [RFC 4287 — The Atom Syndication Format](https://www.rfc-editor.org/rfc/rfc4287)
+- [ADR-0001](0001-structured-validation-errors.md) (shared error grammar)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,15 @@
+# Architecture Decision Records
+
+Each numbered file in this directory captures a single architectural
+decision: the context that forced the call, the alternatives weighed,
+the choice made, and the resulting trade-offs. ADRs are append-only —
+new decisions get a new file rather than rewriting existing history.
+
+| # | Title | Status |
+| :--- | :--- | :--- |
+| [0001](0001-structured-validation-errors.md) | Structured `ValidationError` payload | Accepted (v0.0.6) |
+| [0002](0002-time-only-date-stack.md) | Date stack consolidated on `time` (drop `dtt`) | Accepted (v0.0.6) |
+| [0003](0003-atom-as-sibling-module.md) | Atom 1.0 as a sibling module, not an RSS subtype | Accepted (v0.0.6) |
+
+New ADRs use the [MADR](https://adr.github.io/madr/) template (a
+shortened variant of Michael Nygard's original format).

--- a/examples/example_atom.rs
+++ b/examples/example_atom.rs
@@ -1,0 +1,72 @@
+//! End-to-end Atom 1.0 example.
+//!
+//! Builds an [`AtomFeed`] covering the v0.0.6 capability surface —
+//! multi-author + contributor lists, a `rel="self"` link, an
+//! `<entry>` carrying both `<summary>` and HTML `<content>`, a media
+//! `<link rel="enclosure">` (RFC 4287 §4.2.7.2), and per-entry
+//! categories — then serialises it through [`generate_atom`] and
+//! prints the document.
+//!
+//! Run with: `cargo run --example example_atom`
+
+use rss_gen::{
+    generate_atom, AtomEntry, AtomFeed, AtomLink, AtomPerson,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let feed = AtomFeed::new()
+        .id("urn:example:atom-demo")
+        .title("rss-gen Atom demo")
+        .subtitle("Showcases the surface added in v0.0.6")
+        .updated("2026-06-28T00:00:00Z")
+        .language("en-GB")
+        .generator("rss-gen example_atom")
+        // Multiple feed-level authors plus a contributor.
+        .add_author(
+            AtomPerson::new("Jane Doe")
+                .email("jane@example.com")
+                .uri("https://example.com/~jane"),
+        )
+        .add_author(AtomPerson::new("Sam Roe"))
+        .add_contributor(AtomPerson::new("Ada Reviewer"))
+        // Self link advertises the canonical feed location.
+        .self_link("https://example.com/atom.xml")
+        .alternate_link("https://example.com/")
+        .add_category("rust")
+        .add_category("syndication")
+        // First entry — text summary + HTML content.
+        .add_entry(
+            AtomEntry::new()
+                .id("https://example.com/post-1")
+                .title("Hello, Atom")
+                .updated("2026-06-28T00:00:00Z")
+                .published("2026-06-27T12:00:00Z")
+                .summary("Plain-text summary of the post.")
+                .content_html(
+                    "<p>HTML content body — type=\"html\".</p>",
+                )
+                .alternate_link("https://example.com/post-1")
+                .add_category("intro"),
+        )
+        // Second entry — media enclosure for a podcast episode.
+        .add_entry(
+            AtomEntry::new()
+                .id("https://example.com/ep-1")
+                .title("Episode 1")
+                .updated("2026-06-28T00:00:00Z")
+                .summary("Pilot episode")
+                .add_enclosure(
+                    "https://example.com/ep-1.mp3",
+                    "audio/mpeg",
+                    12_345_678,
+                )
+                .add_link(
+                    AtomLink::alternate("https://example.com/ep-1")
+                        .title("Show notes"),
+                ),
+        );
+
+    let xml = generate_atom(&feed)?;
+    println!("{xml}");
+    Ok(())
+}

--- a/examples/example_detect.rs
+++ b/examples/example_detect.rs
@@ -1,0 +1,53 @@
+//! Demonstrates `detect_feed_format` — the v0.0.6 root-element
+//! classifier that callers use to dispatch between the RSS and Atom
+//! parsing/generation code paths without having to parse the whole
+//! document first.
+//!
+//! Run with: `cargo run --example example_detect`
+
+use rss_gen::{detect_feed_format, FeedFormat};
+
+fn main() {
+    let samples: &[(&str, &str)] = &[
+        (
+            "RSS 2.0",
+            r#"<?xml version="1.0"?>
+<rss version="2.0">
+  <channel><title>Example</title></channel>
+</rss>"#,
+        ),
+        (
+            "RSS 1.0 (RDF)",
+            r#"<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns="http://purl.org/rss/1.0/">
+  <channel rdf:about="https://example.com"/>
+</rdf:RDF>"#,
+        ),
+        (
+            "Atom 1.0 (proper namespace)",
+            r#"<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom"><id/></feed>"#,
+        ),
+        (
+            "Bare <feed> without namespace — must NOT be classified as Atom",
+            r#"<?xml version="1.0"?><feed><id/></feed>"#,
+        ),
+        ("Garbage input", "this is not xml"),
+    ];
+
+    for (label, xml) in samples {
+        let detected = detect_feed_format(xml);
+        // `FeedFormat` is `#[non_exhaustive]` so callers must
+        // include a wildcard arm — keeps adding new variants in
+        // future releases SemVer-minor instead of -major.
+        let verdict = match detected {
+            FeedFormat::Rss => "RSS (2.0 / 0.9x)",
+            FeedFormat::RssRdf => "RSS 1.0 (RDF)",
+            FeedFormat::Atom => "Atom 1.0",
+            FeedFormat::Unknown => "Unknown",
+            _ => "Unhandled (newly added FeedFormat variant)",
+        };
+        println!("[{label}] -> {verdict}");
+    }
+}

--- a/examples/example_error.rs
+++ b/examples/example_error.rs
@@ -121,11 +121,24 @@ fn validation_errors_example() -> Result<()> {
     println!("---------------------------------------------");
 
     let errors = vec![
-        "Title is missing".to_string(),
-        "Invalid publication date".to_string(),
+        rss_gen::ValidationError::new(
+            "channel.title",
+            "channel.title is missing",
+        ),
+        rss_gen::ValidationError::new(
+            "channel.pub_date",
+            "Invalid channel.pub_date: 2026/06/28",
+        ),
     ];
-    let error = RssError::ValidationErrors(errors);
+    let error = RssError::ValidationErrors(errors.clone());
     println!("    ❌  Validation Errors: {}", error);
+    for e in &errors {
+        // Structured access — match on `field`, not on string content.
+        println!(
+            "       • field = {}, message = {}",
+            e.field, e.message
+        );
+    }
 
     Ok(())
 }

--- a/examples/example_validation_errors.rs
+++ b/examples/example_validation_errors.rs
@@ -1,0 +1,88 @@
+//! Shows how v0.0.6's structured `ValidationError` lets callers
+//! dispatch programmatically on `field` rather than parsing strings.
+//!
+//! Demonstrates both the RSS path (`channel.` / `item.0.` prefixes)
+//! and the Atom path (`feed.` / `entry.0.` prefixes), plus the fact
+//! that the validator now accepts RFC 2822 dates with any timezone
+//! (the GMT-only requirement was a P0 spec violation removed in
+//! v0.0.6).
+//!
+//! Run with: `cargo run --example example_validation_errors`
+
+use rss_gen::{
+    generate_atom, generate_rss, AtomEntry, AtomFeed, RssData,
+    RssError, RssItem,
+};
+
+fn main() {
+    print_rss_validation_errors();
+    print_atom_validation_errors();
+    print_date_acceptance();
+}
+
+fn print_rss_validation_errors() {
+    println!("== RSS channel + item validation ==");
+
+    // Channel without title/link/description, plus one item missing
+    // its description — multiple violations at multiple contexts.
+    let mut rss = RssData::new(None);
+    rss.add_item(
+        RssItem::new()
+            .title("Item missing description")
+            .link("https://example.com/post"),
+    );
+
+    match generate_rss(&rss) {
+        Ok(_) => println!("  (no errors)"),
+        Err(RssError::ValidationErrors(errs)) => {
+            for e in &errs {
+                // `field` is the dotted path; `message` is the
+                // human-readable text. `Display` writes the message.
+                println!("  field = {:<24}  message = {}", e.field, e);
+            }
+        }
+        Err(other) => println!("  unexpected error: {other}"),
+    }
+}
+
+fn print_atom_validation_errors() {
+    println!("\n== Atom feed + entry validation ==");
+
+    // Feed missing id/title/updated AND missing feed-level author,
+    // with an entry that lacks its own author — triggers the
+    // RFC 4287 §4.1.1 inheritance rule.
+    let feed = AtomFeed::new().add_entry(
+        AtomEntry::new()
+            .id("urn:example:1")
+            .title("Entry one")
+            .updated("2026-06-28T00:00:00Z"),
+    );
+
+    match generate_atom(&feed) {
+        Ok(_) => println!("  (no errors)"),
+        Err(RssError::ValidationErrors(errs)) => {
+            for e in &errs {
+                println!("  field = {:<24}  message = {}", e.field, e);
+            }
+        }
+        Err(other) => println!("  unexpected error: {other}"),
+    }
+}
+
+fn print_date_acceptance() {
+    use rss_gen::data::parse_date;
+
+    println!("\n== Date parser accepts RFC 2822 + ISO 8601 ==");
+    let inputs = [
+        "Mon, 01 Jan 2024 00:00:00 GMT",
+        "Sun, 28 Jun 2026 00:12:20 +0000",
+        "Sat, 27 Jun 2026 19:12:20 -0500",
+        "2026-06-28T00:12:20Z",
+    ];
+    for input in inputs {
+        match parse_date(input) {
+            Ok(_) => println!("  OK   {input}"),
+            Err(e) => println!("  FAIL {input} ({e})"),
+        }
+    }
+}

--- a/examples/stress_huge_feed.rs
+++ b/examples/stress_huge_feed.rs
@@ -1,0 +1,118 @@
+//! Stress / smoke benchmark — large RSS + Atom emit and format detect.
+//!
+//! Builds a 50 000-item RSS 2.0 feed and a 50 000-entry Atom 1.0 feed,
+//! serialises both, measures wall-clock per stage, and runs the
+//! lightweight `detect_feed_format` classifier across the resulting
+//! megabyte-scale documents to confirm it stays sub-millisecond.
+//!
+//! Run with: `cargo run --release --example stress_huge_feed`
+
+use rss_gen::{
+    detect_feed_format, generate_atom, generate_rss, AtomEntry,
+    AtomFeed, RssData, RssItem, RssVersion,
+};
+use std::time::Instant;
+
+const ITEMS: usize = 50_000;
+const BUDGET_MS: u128 = 1000;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("== rss-gen stress: {ITEMS} items / entries ==\n");
+
+    // ------------------------------------------------------------- RSS
+    let t = Instant::now();
+    let mut rss = RssData::new(Some(RssVersion::RSS2_0))
+        .title("Stress feed")
+        .link("https://example.com")
+        .description("Synthetic large feed used for perf sanity checks")
+        .language("en-GB")
+        .pub_date("Sun, 28 Jun 2026 00:00:00 +0000")
+        .last_build_date("Sun, 28 Jun 2026 00:00:00 +0000")
+        .generator("rss-gen stress_huge_feed")
+        .atom_link("https://example.com/feed.xml");
+    for i in 0..ITEMS {
+        rss.add_item(
+            RssItem::new()
+                .title(format!("Item {i}"))
+                .link(format!("https://example.com/item-{i}"))
+                .description(format!(
+                    "Body for item {i} — Lorem ipsum dolor sit amet."
+                ))
+                .guid(format!("https://example.com/item-{i}"))
+                .pub_date("Sun, 28 Jun 2026 00:00:00 +0000")
+                .author("editor@example.com"),
+        );
+    }
+    let build_ms = t.elapsed().as_millis();
+
+    let t = Instant::now();
+    let rss_xml = generate_rss(&rss)?;
+    let rss_ms = t.elapsed().as_millis();
+
+    report("RSS build", build_ms);
+    report("RSS generate_rss", rss_ms);
+    println!("    bytes emitted: {}", rss_xml.len());
+
+    // ------------------------------------------------------------ Atom
+    let t = Instant::now();
+    let mut atom = AtomFeed::new()
+        .id("urn:example:stress")
+        .title("Stress feed")
+        .updated("2026-06-28T00:00:00Z")
+        .author_name("editor@example.com")
+        .self_link("https://example.com/atom.xml");
+    for i in 0..ITEMS {
+        atom = atom.add_entry(
+            AtomEntry::new()
+                .id(format!("https://example.com/entry-{i}"))
+                .title(format!("Entry {i}"))
+                .updated("2026-06-28T00:00:00Z")
+                .summary(format!("Summary for entry {i}")),
+        );
+    }
+    let atom_build_ms = t.elapsed().as_millis();
+
+    let t = Instant::now();
+    let atom_xml = generate_atom(&atom)?;
+    let atom_ms = t.elapsed().as_millis();
+
+    report("Atom build", atom_build_ms);
+    report("Atom generate_atom", atom_ms);
+    println!("    bytes emitted: {}", atom_xml.len());
+
+    // ---------------------------------------------------- Format detect
+    let t = Instant::now();
+    let rss_kind = detect_feed_format(&rss_xml);
+    let atom_kind = detect_feed_format(&atom_xml);
+    let detect_us = t.elapsed().as_micros();
+    println!(
+        "Format detect on 2 docs ({} bytes total): {} µs total",
+        rss_xml.len() + atom_xml.len(),
+        detect_us
+    );
+    println!("    RSS classified as : {rss_kind:?}");
+    println!("    Atom classified as: {atom_kind:?}");
+
+    // -------------------------------------------- Budget enforcement
+    println!("\nBudget: < {BUDGET_MS} ms per generate stage.");
+    let mut over_budget = Vec::<&'static str>::new();
+    if rss_ms > BUDGET_MS {
+        over_budget.push("RSS generate_rss");
+    }
+    if atom_ms > BUDGET_MS {
+        over_budget.push("Atom generate_atom");
+    }
+    if over_budget.is_empty() {
+        println!("All stages within budget.");
+    } else {
+        for stage in over_budget {
+            eprintln!("OVER BUDGET: {stage}");
+        }
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn report(label: &str, ms: u128) {
+    println!("  {label:<24} {ms:>6} ms");
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,65 @@
+# release-plz config — drives version bumps + crates.io publishing
+# from CI.
+#
+# Workflow: on every push to main, release-plz inspects the conventional
+# commits since the last tag, opens a "release PR" with the bumped
+# version, the regenerated changelog, and the new git-cliff section.
+# Merging that PR triggers `cargo publish` to crates.io.
+
+[workspace]
+# Conventional Commits — generates the CHANGELOG from `feat:` / `fix:`
+# / `chore:` prefixes per Keep a Changelog 1.1.0.
+changelog_update = true
+git_release_enable = true
+
+# Publish to crates.io.
+publish = true
+
+# Don't release the workspace as a whole — each crate has its own
+# version. (Today we have only one crate; this is forward-compatible
+# with a future workspace split.)
+release = true
+
+# Verify the published tarball matches the local one by running
+# `cargo publish --dry-run` before tagging.
+publish_features = ["all"]
+
+# Sign the git tag with the maintainer's SSH/GPG key.
+git_tag_name = "v{{ version }}"
+git_release_name = "v{{ version }}"
+
+# release-plz writes release notes by extracting the matching CHANGELOG
+# section between the previous tag and the new one.
+git_release_body = """
+{% if release_body -%}
+{{ release_body }}
+{% else %}
+See the [CHANGELOG]({{ changelog_url }}) for the full diff.
+{% endif %}
+"""
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to `rss-gen` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""
+
+# Conventional Commit prefix → CHANGELOG section.
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^test", group = "Testing" },
+  { message = "^ci", group = "Tooling" },
+  { message = "^chore\\(deps\\)", group = "Dependencies" },
+  { message = "^chore", skip = true },
+  { message = "^style", skip = true },
+]
+
+# Treat anything matching these as a hard breaking-change marker.
+sort_commits = "newest"

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -47,7 +47,7 @@
 //! assert!(xml.contains(r#"<feed xmlns="http://www.w3.org/2005/Atom">"#));
 //! ```
 
-use crate::error::{Result, RssError};
+use crate::error::{Result, RssError, ValidationError};
 use crate::generator::sanitize_content;
 use quick_xml::events::{
     BytesDecl, BytesEnd, BytesStart, BytesText, Event,
@@ -489,20 +489,32 @@ impl AtomFeed {
     /// Returns [`RssError::ValidationErrors`] containing every missing or
     /// invalid required element discovered.
     pub fn validate(&self) -> Result<()> {
-        let mut errors = Vec::new();
+        let mut errors: Vec<ValidationError> = Vec::new();
 
         if self.id.is_empty() {
-            errors.push("feed.id is missing".to_string());
+            errors.push(ValidationError::new(
+                "feed.id",
+                "feed.id is missing",
+            ));
         }
         if self.title.is_empty() {
-            errors.push("feed.title is missing".to_string());
+            errors.push(ValidationError::new(
+                "feed.title",
+                "feed.title is missing",
+            ));
         }
         if self.updated.is_empty() {
-            errors.push("feed.updated is missing".to_string());
+            errors.push(ValidationError::new(
+                "feed.updated",
+                "feed.updated is missing",
+            ));
         } else if !is_rfc3339(&self.updated) {
-            errors.push(format!(
-                "feed.updated is not a valid RFC 3339 timestamp: {}",
-                self.updated
+            errors.push(ValidationError::new(
+                "feed.updated",
+                format!(
+                    "feed.updated is not a valid RFC 3339 timestamp: {}",
+                    self.updated
+                ),
             ));
         }
 
@@ -517,9 +529,12 @@ impl AtomFeed {
                 errors.append(&mut entry_errors);
             }
             if !feed_has_author && entry.authors.is_empty() {
-                errors.push(format!(
-                    "entry.{idx}.author is missing (and feed has no \
-                     feed-level author)"
+                errors.push(ValidationError::new(
+                    format!("entry.{idx}.author"),
+                    format!(
+                        "entry.{idx}.author is missing (and feed has \
+                         no feed-level author)"
+                    ),
                 ));
             }
         }
@@ -664,7 +679,7 @@ impl AtomEntry {
     /// Returns [`RssError::ValidationErrors`] containing every missing or
     /// invalid required element discovered.
     pub fn validate(&self) -> Result<()> {
-        let mut errors = Vec::new();
+        let mut errors: Vec<ValidationError> = Vec::new();
         push_entry_errors(self, "entry.", &mut errors);
         if errors.is_empty() {
             Ok(())
@@ -675,7 +690,7 @@ impl AtomEntry {
 
     fn validate_with_index(&self, idx: usize) -> Result<()> {
         let prefix = format!("entry.{idx}.");
-        let mut errors = Vec::new();
+        let mut errors: Vec<ValidationError> = Vec::new();
         push_entry_errors(self, &prefix, &mut errors);
         if errors.is_empty() {
             Ok(())
@@ -688,26 +703,43 @@ impl AtomEntry {
 fn push_entry_errors(
     entry: &AtomEntry,
     prefix: &str,
-    errors: &mut Vec<String>,
+    errors: &mut Vec<ValidationError>,
 ) {
+    let field_path = |suffix: &str| format!("{prefix}{suffix}");
+
     if entry.id.is_empty() {
-        errors.push(format!("{prefix}id is missing"));
+        errors.push(ValidationError::new(
+            field_path("id"),
+            format!("{prefix}id is missing"),
+        ));
     }
     if entry.title.is_empty() {
-        errors.push(format!("{prefix}title is missing"));
+        errors.push(ValidationError::new(
+            field_path("title"),
+            format!("{prefix}title is missing"),
+        ));
     }
     if entry.updated.is_empty() {
-        errors.push(format!("{prefix}updated is missing"));
+        errors.push(ValidationError::new(
+            field_path("updated"),
+            format!("{prefix}updated is missing"),
+        ));
     } else if !is_rfc3339(&entry.updated) {
-        errors.push(format!(
-            "{prefix}updated is not a valid RFC 3339 timestamp: {}",
-            entry.updated
+        errors.push(ValidationError::new(
+            field_path("updated"),
+            format!(
+                "{prefix}updated is not a valid RFC 3339 timestamp: {}",
+                entry.updated
+            ),
         ));
     }
     if !entry.published.is_empty() && !is_rfc3339(&entry.published) {
-        errors.push(format!(
-            "{prefix}published is not a valid RFC 3339 timestamp: {}",
-            entry.published
+        errors.push(ValidationError::new(
+            field_path("published"),
+            format!(
+                "{prefix}published is not a valid RFC 3339 timestamp: {}",
+                entry.published
+            ),
         ));
     }
 }
@@ -940,12 +972,15 @@ mod tests {
     fn validate_rejects_missing_required_fields() {
         let feed = AtomFeed::new();
         let err = feed.validate().unwrap_err();
-        let RssError::ValidationErrors(msgs) = err else {
+        let RssError::ValidationErrors(errs) = err else {
             panic!("expected ValidationErrors");
         };
-        assert!(msgs.iter().any(|m| m == "feed.id is missing"));
-        assert!(msgs.iter().any(|m| m == "feed.title is missing"));
-        assert!(msgs.iter().any(|m| m == "feed.updated is missing"));
+        assert!(errs.iter().any(|e| e.field == "feed.id"
+            && e.message == "feed.id is missing"));
+        assert!(errs.iter().any(|e| e.field == "feed.title"
+            && e.message == "feed.title is missing"));
+        assert!(errs.iter().any(|e| e.field == "feed.updated"
+            && e.message == "feed.updated is missing"));
     }
 
     #[test]
@@ -956,12 +991,13 @@ mod tests {
             .updated("yesterday afternoon")
             .author_name("Tester");
         let err = feed.validate().unwrap_err();
-        let RssError::ValidationErrors(msgs) = err else {
+        let RssError::ValidationErrors(errs) = err else {
             panic!("expected ValidationErrors");
         };
-        assert!(msgs.iter().any(|m| m.starts_with(
-            "feed.updated is not a valid RFC 3339 timestamp"
-        )));
+        assert!(errs.iter().any(|e| e.field == "feed.updated"
+            && e.message.starts_with(
+                "feed.updated is not a valid RFC 3339 timestamp"
+            )));
     }
 
     #[test]
@@ -977,22 +1013,25 @@ mod tests {
                     .updated("2026-06-27T00:00:00Z"),
             );
         let err = feed.validate().unwrap_err();
-        let RssError::ValidationErrors(msgs) = err else {
+        let RssError::ValidationErrors(errs) = err else {
             panic!("expected ValidationErrors");
         };
-        assert!(msgs.iter().any(|m| m.contains("entry.0.author")));
+        assert!(errs.iter().any(|e| e.field == "entry.0.author"));
     }
 
     #[test]
     fn entry_validate_uses_unindexed_prefix() {
         let entry = AtomEntry::new();
         let err = entry.validate().unwrap_err();
-        let RssError::ValidationErrors(msgs) = err else {
+        let RssError::ValidationErrors(errs) = err else {
             panic!("expected ValidationErrors");
         };
-        assert!(msgs.iter().any(|m| m == "entry.id is missing"));
-        assert!(msgs.iter().any(|m| m == "entry.title is missing"));
-        assert!(msgs.iter().any(|m| m == "entry.updated is missing"));
+        assert!(errs.iter().any(|e| e.field == "entry.id"
+            && e.message == "entry.id is missing"));
+        assert!(errs.iter().any(|e| e.field == "entry.title"
+            && e.message == "entry.title is missing"));
+        assert!(errs.iter().any(|e| e.field == "entry.updated"
+            && e.message == "entry.updated is missing"));
     }
 
     #[test]

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -1,0 +1,1102 @@
+// Copyright © 2026 RSS Gen. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// src/atom.rs
+
+//! Atom 1.0 feed generation, validation, and format detection.
+//!
+//! This module implements the subset of [RFC 4287](https://www.rfc-editor.org/rfc/rfc4287)
+//! needed to author syndication feeds in the Atom 1.0 format alongside the
+//! existing RSS support. It is fully independent of the RSS code path: callers
+//! that want Atom output construct an [`AtomFeed`], add [`AtomEntry`] values
+//! via the builder API, and serialize through [`generate_atom`].
+//!
+//! It also exposes [`FeedFormat`] and [`detect_feed_format`] for callers that
+//! need to dispatch between RSS and Atom inputs without parsing the whole
+//! document.
+//!
+//! # Required elements (RFC 4287 §4.1.1 & §4.1.2)
+//!
+//! * `<feed>`: `id`, `title`, `updated` are required.
+//! * `<entry>`: `id`, `title`, `updated` are required.
+//!
+//! Validation in this module enforces those required elements and prefixes
+//! reported errors with `feed.` / `entry.<idx>.` to stay consistent with the
+//! contextual validation errors introduced for the RSS path in issue #34.
+//!
+//! # Example
+//!
+//! ```rust
+//! use rss_gen::atom::{generate_atom, AtomEntry, AtomFeed};
+//!
+//! let feed = AtomFeed::new()
+//!     .id("https://example.com/feed")
+//!     .title("Example Feed")
+//!     .updated("2026-06-27T00:00:00Z")
+//!     .author_name("Jane Doe")
+//!     .self_link("https://example.com/atom.xml")
+//!     .add_entry(
+//!         AtomEntry::new()
+//!             .id("https://example.com/post-1")
+//!             .title("First Post")
+//!             .updated("2026-06-27T00:00:00Z")
+//!             .summary("Hello, Atom"),
+//!     );
+//!
+//! let xml = generate_atom(&feed).unwrap();
+//! assert!(xml.contains(r#"<feed xmlns="http://www.w3.org/2005/Atom">"#));
+//! ```
+
+use crate::error::{Result, RssError};
+use crate::generator::sanitize_content;
+use quick_xml::events::{
+    BytesDecl, BytesEnd, BytesStart, BytesText, Event,
+};
+use quick_xml::Writer;
+use serde::{Deserialize, Serialize};
+use std::io::Cursor;
+
+/// Atom 1.0 namespace literal used on the root `<feed>` element.
+pub const ATOM_NAMESPACE: &str = "http://www.w3.org/2005/Atom";
+
+const XML_VERSION: &str = "1.0";
+const XML_ENCODING: &str = "utf-8";
+
+/// Discriminates between supported feed formats.
+///
+/// Returned by [`detect_feed_format`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum FeedFormat {
+    /// RSS 0.9x / 2.0 (`<rss>` root element).
+    Rss,
+    /// RSS 1.0 (`<rdf:RDF>` root element).
+    RssRdf,
+    /// Atom 1.0 (`<feed xmlns="http://www.w3.org/2005/Atom">` root).
+    Atom,
+    /// The document could not be classified.
+    Unknown,
+}
+
+/// Peeks the root element of an XML document and returns the detected
+/// [`FeedFormat`].
+///
+/// This is a lightweight heuristic intended for dispatching between
+/// [`crate::generator::generate_rss`] / [`crate::parser::parse_rss`] and the
+/// Atom code path. It reads only as far as the first start element and does
+/// not validate the document.
+///
+/// # Examples
+///
+/// ```rust
+/// use rss_gen::atom::{detect_feed_format, FeedFormat};
+///
+/// let rss = r#"<?xml version="1.0"?><rss version="2.0"><channel/></rss>"#;
+/// assert_eq!(detect_feed_format(rss), FeedFormat::Rss);
+///
+/// let atom = r#"<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"/>"#;
+/// assert_eq!(detect_feed_format(atom), FeedFormat::Atom);
+/// ```
+#[must_use]
+pub fn detect_feed_format(xml: &str) -> FeedFormat {
+    use quick_xml::Reader;
+
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    let mut buf = Vec::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(start) | Event::Empty(start)) => {
+                let name = start.name();
+                let local = name.as_ref();
+                if local == b"rss" {
+                    return FeedFormat::Rss;
+                }
+                if local == b"rdf:RDF" || local == b"RDF" {
+                    return FeedFormat::RssRdf;
+                }
+                if local == b"feed" {
+                    // Only classify as Atom if the namespace matches —
+                    // some hand-rolled feeds use <feed> with no xmlns.
+                    let has_atom_ns =
+                        start.attributes().flatten().any(|a| {
+                            a.key.as_ref() == b"xmlns"
+                                && a.value.as_ref()
+                                    == ATOM_NAMESPACE.as_bytes()
+                        });
+                    return if has_atom_ns {
+                        FeedFormat::Atom
+                    } else {
+                        FeedFormat::Unknown
+                    };
+                }
+                return FeedFormat::Unknown;
+            }
+            Ok(Event::Eof) | Err(_) => return FeedFormat::Unknown,
+            Ok(_) => buf.clear(),
+        }
+    }
+}
+
+/// A person reference (`<author>` / `<contributor>`) per RFC 4287 §3.2.
+#[derive(
+    Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize,
+)]
+#[non_exhaustive]
+pub struct AtomPerson {
+    /// Human-readable name (required by the spec).
+    pub name: String,
+    /// Optional email address.
+    pub email: String,
+    /// Optional homepage URI.
+    pub uri: String,
+}
+
+impl AtomPerson {
+    /// Creates a new `AtomPerson` with the given name and empty contact
+    /// fields.
+    #[must_use]
+    pub fn new<S: Into<String>>(name: S) -> Self {
+        Self {
+            name: sanitize_input(&name.into()),
+            ..Self::default()
+        }
+    }
+
+    /// Sets the email address.
+    #[must_use]
+    pub fn email<S: Into<String>>(mut self, value: S) -> Self {
+        self.email = sanitize_input(&value.into());
+        self
+    }
+
+    /// Sets the homepage URI.
+    #[must_use]
+    pub fn uri<S: Into<String>>(mut self, value: S) -> Self {
+        self.uri = sanitize_input(&value.into());
+        self
+    }
+}
+
+/// An Atom `<link>` element per RFC 4287 §4.2.7.
+///
+/// Atom links are typed pointers; the canonical alternate link to the
+/// resource is `rel="alternate"` and self-references use `rel="self"`. Media
+/// enclosures (e.g. podcasts) use `rel="enclosure"` together with the `type`
+/// and `length` attributes.
+#[derive(
+    Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize,
+)]
+#[non_exhaustive]
+pub struct AtomLink {
+    /// Target URI of the link.
+    pub href: String,
+    /// Link relation (`alternate`, `self`, `enclosure`, …). Empty means
+    /// `alternate`, per RFC 4287 §4.2.7.2.
+    pub rel: String,
+    /// MIME type of the linked resource.
+    pub mime_type: String,
+    /// Length in bytes (relevant for `rel="enclosure"`).
+    pub length: String,
+    /// Optional human-readable title.
+    pub title: String,
+}
+
+impl AtomLink {
+    /// Constructs an `AtomLink` with the given href, defaulting to
+    /// `rel="alternate"`.
+    #[must_use]
+    pub fn alternate<S: Into<String>>(href: S) -> Self {
+        Self {
+            href: sanitize_input(&href.into()),
+            rel: "alternate".to_string(),
+            ..Self::default()
+        }
+    }
+
+    /// Constructs a `rel="self"` link pointing at the canonical location of
+    /// the feed.
+    #[must_use]
+    pub fn self_ref<S: Into<String>>(href: S) -> Self {
+        Self {
+            href: sanitize_input(&href.into()),
+            rel: "self".to_string(),
+            ..Self::default()
+        }
+    }
+
+    /// Constructs a `rel="enclosure"` link for a media attachment.
+    #[must_use]
+    pub fn enclosure<S, T>(href: S, mime_type: T, length: u64) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        Self {
+            href: sanitize_input(&href.into()),
+            rel: "enclosure".to_string(),
+            mime_type: sanitize_input(&mime_type.into()),
+            length: length.to_string(),
+            ..Self::default()
+        }
+    }
+
+    /// Sets the optional title attribute.
+    #[must_use]
+    pub fn title<S: Into<String>>(mut self, value: S) -> Self {
+        self.title = sanitize_input(&value.into());
+        self
+    }
+}
+
+/// Text content for `<title>`, `<summary>`, `<content>` per RFC 4287 §3.1.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+)]
+#[non_exhaustive]
+pub enum AtomTextType {
+    /// Plain text. Special characters are XML-escaped.
+    #[default]
+    Text,
+    /// HTML payload. Treated as opaque text by this module and emitted
+    /// verbatim after XML-escaping; consumers are responsible for ensuring
+    /// the payload is safe.
+    Html,
+}
+
+impl AtomTextType {
+    fn as_attr(self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::Html => "html",
+        }
+    }
+}
+
+/// An Atom 1.0 feed (`<feed>`) document.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AtomFeed {
+    /// Permanent, universally unique identifier of the feed (RFC 4287 §4.2.6).
+    pub id: String,
+    /// Human-readable title of the feed.
+    pub title: String,
+    /// Optional human-readable subtitle.
+    pub subtitle: String,
+    /// RFC 3339 timestamp of the most recent significant modification.
+    pub updated: String,
+    /// Optional rights / copyright string.
+    pub rights: String,
+    /// Generator identification (e.g. `"rss-gen"`).
+    pub generator: String,
+    /// Optional URI of a small icon representing the feed.
+    pub icon: String,
+    /// Optional URI of a larger logo representing the feed.
+    pub logo: String,
+    /// Language tag (e.g. `"en-US"`). Emitted as `xml:lang` on `<feed>`.
+    pub language: String,
+    /// Authors of the feed.
+    pub authors: Vec<AtomPerson>,
+    /// Contributors to the feed.
+    pub contributors: Vec<AtomPerson>,
+    /// Links advertised at feed level (`self`, `alternate`, …).
+    pub links: Vec<AtomLink>,
+    /// Category tags applied to the feed (term values only).
+    pub categories: Vec<String>,
+    /// Entries contained in the feed.
+    pub entries: Vec<AtomEntry>,
+}
+
+/// An Atom 1.0 entry (`<entry>`).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AtomEntry {
+    /// Permanent, universally unique identifier of the entry.
+    pub id: String,
+    /// Human-readable title.
+    pub title: String,
+    /// RFC 3339 timestamp of the most recent significant modification.
+    pub updated: String,
+    /// Optional RFC 3339 publication timestamp.
+    pub published: String,
+    /// Short human-readable description.
+    pub summary: String,
+    /// Type of the `summary` payload.
+    pub summary_type: AtomTextType,
+    /// Full content payload (may be empty).
+    pub content: String,
+    /// Type of the `content` payload.
+    pub content_type: AtomTextType,
+    /// Optional rights string.
+    pub rights: String,
+    /// Authors of the entry.
+    pub authors: Vec<AtomPerson>,
+    /// Contributors to the entry.
+    pub contributors: Vec<AtomPerson>,
+    /// Links attached to the entry, including media enclosures.
+    pub links: Vec<AtomLink>,
+    /// Category tags applied to the entry (term values only).
+    pub categories: Vec<String>,
+}
+
+impl AtomFeed {
+    /// Creates an empty `AtomFeed`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the feed's permanent identifier.
+    #[must_use]
+    pub fn id<S: Into<String>>(mut self, value: S) -> Self {
+        self.id = sanitize_input(&value.into());
+        self
+    }
+
+    /// Sets the feed title.
+    #[must_use]
+    pub fn title<S: Into<String>>(mut self, value: S) -> Self {
+        self.title = sanitize_input(&value.into());
+        self
+    }
+
+    /// Sets the feed subtitle.
+    #[must_use]
+    pub fn subtitle<S: Into<String>>(mut self, value: S) -> Self {
+        self.subtitle = sanitize_input(&value.into());
+        self
+    }
+
+    /// Sets the feed-level `updated` timestamp (RFC 3339).
+    #[must_use]
+    pub fn updated<S: Into<String>>(mut self, value: S) -> Self {
+        self.updated = sanitize_input(&value.into());
+        self
+    }
+
+    /// Sets the rights string.
+    #[must_use]
+    pub fn rights<S: Into<String>>(mut self, value: S) -> Self {
+        self.rights = sanitize_input(&value.into());
+        self
+    }
+
+    /// Sets the generator string.
+    #[must_use]
+    pub fn generator<S: Into<String>>(mut self, value: S) -> Self {
+        self.generator = sanitize_input(&value.into());
+        self
+    }
+
+    /// Sets the icon URI.
+    #[must_use]
+    pub fn icon<S: Into<String>>(mut self, value: S) -> Self {
+        self.icon = sanitize_input(&value.into());
+        self
+    }
+
+    /// Sets the logo URI.
+    #[must_use]
+    pub fn logo<S: Into<String>>(mut self, value: S) -> Self {
+        self.logo = sanitize_input(&value.into());
+        self
+    }
+
+    /// Sets the `xml:lang` value.
+    #[must_use]
+    pub fn language<S: Into<String>>(mut self, value: S) -> Self {
+        self.language = sanitize_input(&value.into());
+        self
+    }
+
+    /// Adds an author with the given name.
+    #[must_use]
+    pub fn author_name<S: Into<String>>(mut self, name: S) -> Self {
+        self.authors.push(AtomPerson::new(name));
+        self
+    }
+
+    /// Adds an [`AtomPerson`] to the author list.
+    #[must_use]
+    pub fn add_author(mut self, author: AtomPerson) -> Self {
+        self.authors.push(author);
+        self
+    }
+
+    /// Adds an [`AtomPerson`] to the contributor list.
+    #[must_use]
+    pub fn add_contributor(mut self, contributor: AtomPerson) -> Self {
+        self.contributors.push(contributor);
+        self
+    }
+
+    /// Adds an [`AtomLink`] to the feed.
+    #[must_use]
+    pub fn add_link(mut self, link: AtomLink) -> Self {
+        self.links.push(link);
+        self
+    }
+
+    /// Convenience: adds a `rel="self"` link to the canonical feed URL.
+    #[must_use]
+    pub fn self_link<S: Into<String>>(self, href: S) -> Self {
+        self.add_link(AtomLink::self_ref(href))
+    }
+
+    /// Convenience: adds a `rel="alternate"` link to the human page.
+    #[must_use]
+    pub fn alternate_link<S: Into<String>>(self, href: S) -> Self {
+        self.add_link(AtomLink::alternate(href))
+    }
+
+    /// Adds a category tag.
+    #[must_use]
+    pub fn add_category<S: Into<String>>(mut self, term: S) -> Self {
+        self.categories.push(sanitize_input(&term.into()));
+        self
+    }
+
+    /// Appends an entry to the feed.
+    #[must_use]
+    pub fn add_entry(mut self, entry: AtomEntry) -> Self {
+        self.entries.push(entry);
+        self
+    }
+
+    /// Number of entries in the feed.
+    #[must_use]
+    pub fn entry_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Validates the feed against the required RFC 4287 elements.
+    ///
+    /// Error messages are prefixed with `feed.` for top-level violations
+    /// and `entry.<idx>.` for per-entry violations, matching the contextual
+    /// validation introduced in issue #34 for the RSS code path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RssError::ValidationErrors`] containing every missing or
+    /// invalid required element discovered.
+    pub fn validate(&self) -> Result<()> {
+        let mut errors = Vec::new();
+
+        if self.id.is_empty() {
+            errors.push("feed.id is missing".to_string());
+        }
+        if self.title.is_empty() {
+            errors.push("feed.title is missing".to_string());
+        }
+        if self.updated.is_empty() {
+            errors.push("feed.updated is missing".to_string());
+        } else if !is_rfc3339(&self.updated) {
+            errors.push(format!(
+                "feed.updated is not a valid RFC 3339 timestamp: {}",
+                self.updated
+            ));
+        }
+
+        // RFC 4287 §4.1.1: a feed without a feed-level author MUST have
+        // an author on every entry. Surface that explicitly so callers
+        // don't silently emit a non-conformant document.
+        let feed_has_author = !self.authors.is_empty();
+        for (idx, entry) in self.entries.iter().enumerate() {
+            if let Err(RssError::ValidationErrors(mut entry_errors)) =
+                entry.validate_with_index(idx)
+            {
+                errors.append(&mut entry_errors);
+            }
+            if !feed_has_author && entry.authors.is_empty() {
+                errors.push(format!(
+                    "entry.{idx}.author is missing (and feed has no \
+                     feed-level author)"
+                ));
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(RssError::ValidationErrors(errors))
+        }
+    }
+}
+
+impl AtomEntry {
+    /// Creates an empty `AtomEntry`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the entry's permanent identifier.
+    #[must_use]
+    pub fn id<S: Into<String>>(mut self, value: S) -> Self {
+        self.id = sanitize_input(&value.into());
+        self
+    }
+
+    /// Sets the entry title.
+    #[must_use]
+    pub fn title<S: Into<String>>(mut self, value: S) -> Self {
+        self.title = sanitize_input(&value.into());
+        self
+    }
+
+    /// Sets the entry-level `updated` timestamp (RFC 3339).
+    #[must_use]
+    pub fn updated<S: Into<String>>(mut self, value: S) -> Self {
+        self.updated = sanitize_input(&value.into());
+        self
+    }
+
+    /// Sets the entry-level `published` timestamp (RFC 3339).
+    #[must_use]
+    pub fn published<S: Into<String>>(mut self, value: S) -> Self {
+        self.published = sanitize_input(&value.into());
+        self
+    }
+
+    /// Sets the plain-text summary.
+    #[must_use]
+    pub fn summary<S: Into<String>>(mut self, value: S) -> Self {
+        self.summary = sanitize_input(&value.into());
+        self.summary_type = AtomTextType::Text;
+        self
+    }
+
+    /// Sets the HTML summary payload.
+    #[must_use]
+    pub fn summary_html<S: Into<String>>(mut self, value: S) -> Self {
+        self.summary = sanitize_input(&value.into());
+        self.summary_type = AtomTextType::Html;
+        self
+    }
+
+    /// Sets the plain-text content payload.
+    #[must_use]
+    pub fn content<S: Into<String>>(mut self, value: S) -> Self {
+        self.content = sanitize_input(&value.into());
+        self.content_type = AtomTextType::Text;
+        self
+    }
+
+    /// Sets the HTML content payload.
+    #[must_use]
+    pub fn content_html<S: Into<String>>(mut self, value: S) -> Self {
+        self.content = sanitize_input(&value.into());
+        self.content_type = AtomTextType::Html;
+        self
+    }
+
+    /// Sets the rights string.
+    #[must_use]
+    pub fn rights<S: Into<String>>(mut self, value: S) -> Self {
+        self.rights = sanitize_input(&value.into());
+        self
+    }
+
+    /// Adds an author with the given name.
+    #[must_use]
+    pub fn author_name<S: Into<String>>(mut self, name: S) -> Self {
+        self.authors.push(AtomPerson::new(name));
+        self
+    }
+
+    /// Adds an [`AtomPerson`] to the entry's author list.
+    #[must_use]
+    pub fn add_author(mut self, author: AtomPerson) -> Self {
+        self.authors.push(author);
+        self
+    }
+
+    /// Adds an [`AtomLink`] to the entry.
+    #[must_use]
+    pub fn add_link(mut self, link: AtomLink) -> Self {
+        self.links.push(link);
+        self
+    }
+
+    /// Convenience: adds a `rel="alternate"` link to the entry's resource.
+    #[must_use]
+    pub fn alternate_link<S: Into<String>>(self, href: S) -> Self {
+        self.add_link(AtomLink::alternate(href))
+    }
+
+    /// Convenience: attaches a media enclosure (RFC 4287 §4.2.7.2).
+    #[must_use]
+    pub fn add_enclosure<S, T>(
+        self,
+        href: S,
+        mime_type: T,
+        length: u64,
+    ) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.add_link(AtomLink::enclosure(href, mime_type, length))
+    }
+
+    /// Adds a category tag.
+    #[must_use]
+    pub fn add_category<S: Into<String>>(mut self, term: S) -> Self {
+        self.categories.push(sanitize_input(&term.into()));
+        self
+    }
+
+    /// Validates the entry against RFC 4287 §4.1.2 required elements.
+    ///
+    /// Error messages are prefixed with `entry.` (no index).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RssError::ValidationErrors`] containing every missing or
+    /// invalid required element discovered.
+    pub fn validate(&self) -> Result<()> {
+        let mut errors = Vec::new();
+        push_entry_errors(self, "entry.", &mut errors);
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(RssError::ValidationErrors(errors))
+        }
+    }
+
+    fn validate_with_index(&self, idx: usize) -> Result<()> {
+        let prefix = format!("entry.{idx}.");
+        let mut errors = Vec::new();
+        push_entry_errors(self, &prefix, &mut errors);
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(RssError::ValidationErrors(errors))
+        }
+    }
+}
+
+fn push_entry_errors(
+    entry: &AtomEntry,
+    prefix: &str,
+    errors: &mut Vec<String>,
+) {
+    if entry.id.is_empty() {
+        errors.push(format!("{prefix}id is missing"));
+    }
+    if entry.title.is_empty() {
+        errors.push(format!("{prefix}title is missing"));
+    }
+    if entry.updated.is_empty() {
+        errors.push(format!("{prefix}updated is missing"));
+    } else if !is_rfc3339(&entry.updated) {
+        errors.push(format!(
+            "{prefix}updated is not a valid RFC 3339 timestamp: {}",
+            entry.updated
+        ));
+    }
+    if !entry.published.is_empty() && !is_rfc3339(&entry.published) {
+        errors.push(format!(
+            "{prefix}published is not a valid RFC 3339 timestamp: {}",
+            entry.published
+        ));
+    }
+}
+
+fn is_rfc3339(value: &str) -> bool {
+    use time::format_description::well_known::Rfc3339;
+    use time::OffsetDateTime;
+    OffsetDateTime::parse(value, &Rfc3339).is_ok()
+}
+
+fn sanitize_input(value: &str) -> String {
+    value
+        .chars()
+        .filter(|c| !c.is_control() || matches!(*c, '\n' | '\r' | '\t'))
+        .collect()
+}
+
+/// Serializes an [`AtomFeed`] into an Atom 1.0 XML string.
+///
+/// Validation runs first via [`AtomFeed::validate`]; invalid feeds return
+/// the validation errors unchanged. On success the produced string is a
+/// stand-alone Atom 1.0 document with `xmlns="http://www.w3.org/2005/Atom"`
+/// on the root element.
+///
+/// # Errors
+///
+/// Returns [`RssError::ValidationErrors`] when required elements are missing
+/// or malformed, or [`RssError::XmlWriteError`] when the underlying XML
+/// writer fails.
+pub fn generate_atom(feed: &AtomFeed) -> Result<String> {
+    feed.validate()?;
+
+    let mut writer = Writer::new(Cursor::new(Vec::new()));
+
+    writer.write_event(Event::Decl(BytesDecl::new(
+        XML_VERSION,
+        Some(XML_ENCODING),
+        None,
+    )))?;
+
+    let mut feed_start = BytesStart::new("feed");
+    feed_start.push_attribute(("xmlns", ATOM_NAMESPACE));
+    if !feed.language.is_empty() {
+        feed_start.push_attribute(("xml:lang", feed.language.as_str()));
+    }
+    writer.write_event(Event::Start(feed_start))?;
+
+    write_text_element(&mut writer, "id", &feed.id)?;
+    write_text_element(&mut writer, "title", &feed.title)?;
+    write_text_element(&mut writer, "updated", &feed.updated)?;
+    if !feed.subtitle.is_empty() {
+        write_text_element(&mut writer, "subtitle", &feed.subtitle)?;
+    }
+    if !feed.rights.is_empty() {
+        write_text_element(&mut writer, "rights", &feed.rights)?;
+    }
+    if !feed.icon.is_empty() {
+        write_text_element(&mut writer, "icon", &feed.icon)?;
+    }
+    if !feed.logo.is_empty() {
+        write_text_element(&mut writer, "logo", &feed.logo)?;
+    }
+    if !feed.generator.is_empty() {
+        write_text_element(&mut writer, "generator", &feed.generator)?;
+    }
+
+    for person in &feed.authors {
+        write_person(&mut writer, "author", person)?;
+    }
+    for person in &feed.contributors {
+        write_person(&mut writer, "contributor", person)?;
+    }
+    for link in &feed.links {
+        write_link(&mut writer, link)?;
+    }
+    for category in &feed.categories {
+        write_category(&mut writer, category)?;
+    }
+
+    for entry in &feed.entries {
+        write_entry(&mut writer, entry)?;
+    }
+
+    writer.write_event(Event::End(BytesEnd::new("feed")))?;
+
+    let xml = writer.into_inner().into_inner();
+    String::from_utf8(xml).map_err(RssError::from)
+}
+
+fn write_text_element<W: std::io::Write>(
+    writer: &mut Writer<W>,
+    name: &str,
+    content: &str,
+) -> Result<()> {
+    let escaped = sanitize_content(content);
+    writer.write_event(Event::Start(BytesStart::new(name)))?;
+    writer
+        .write_event(Event::Text(BytesText::from_escaped(escaped)))?;
+    writer.write_event(Event::End(BytesEnd::new(name)))?;
+    Ok(())
+}
+
+fn write_typed_text<W: std::io::Write>(
+    writer: &mut Writer<W>,
+    name: &str,
+    content: &str,
+    text_type: AtomTextType,
+) -> Result<()> {
+    let escaped = sanitize_content(content);
+    let mut start = BytesStart::new(name);
+    start.push_attribute(("type", text_type.as_attr()));
+    writer.write_event(Event::Start(start))?;
+    writer
+        .write_event(Event::Text(BytesText::from_escaped(escaped)))?;
+    writer.write_event(Event::End(BytesEnd::new(name)))?;
+    Ok(())
+}
+
+fn write_person<W: std::io::Write>(
+    writer: &mut Writer<W>,
+    element: &str,
+    person: &AtomPerson,
+) -> Result<()> {
+    writer.write_event(Event::Start(BytesStart::new(element)))?;
+    write_text_element(writer, "name", &person.name)?;
+    if !person.email.is_empty() {
+        write_text_element(writer, "email", &person.email)?;
+    }
+    if !person.uri.is_empty() {
+        write_text_element(writer, "uri", &person.uri)?;
+    }
+    writer.write_event(Event::End(BytesEnd::new(element)))?;
+    Ok(())
+}
+
+fn write_link<W: std::io::Write>(
+    writer: &mut Writer<W>,
+    link: &AtomLink,
+) -> Result<()> {
+    let mut start = BytesStart::new("link");
+    start.push_attribute(("href", link.href.as_str()));
+    if !link.rel.is_empty() {
+        start.push_attribute(("rel", link.rel.as_str()));
+    }
+    if !link.mime_type.is_empty() {
+        start.push_attribute(("type", link.mime_type.as_str()));
+    }
+    if !link.length.is_empty() {
+        start.push_attribute(("length", link.length.as_str()));
+    }
+    if !link.title.is_empty() {
+        start.push_attribute(("title", link.title.as_str()));
+    }
+    writer.write_event(Event::Empty(start))?;
+    Ok(())
+}
+
+fn write_category<W: std::io::Write>(
+    writer: &mut Writer<W>,
+    term: &str,
+) -> Result<()> {
+    let mut start = BytesStart::new("category");
+    start.push_attribute(("term", term));
+    writer.write_event(Event::Empty(start))?;
+    Ok(())
+}
+
+fn write_entry<W: std::io::Write>(
+    writer: &mut Writer<W>,
+    entry: &AtomEntry,
+) -> Result<()> {
+    writer.write_event(Event::Start(BytesStart::new("entry")))?;
+
+    write_text_element(writer, "id", &entry.id)?;
+    write_text_element(writer, "title", &entry.title)?;
+    write_text_element(writer, "updated", &entry.updated)?;
+    if !entry.published.is_empty() {
+        write_text_element(writer, "published", &entry.published)?;
+    }
+    if !entry.summary.is_empty() {
+        write_typed_text(
+            writer,
+            "summary",
+            &entry.summary,
+            entry.summary_type,
+        )?;
+    }
+    if !entry.content.is_empty() {
+        write_typed_text(
+            writer,
+            "content",
+            &entry.content,
+            entry.content_type,
+        )?;
+    }
+    if !entry.rights.is_empty() {
+        write_text_element(writer, "rights", &entry.rights)?;
+    }
+
+    for person in &entry.authors {
+        write_person(writer, "author", person)?;
+    }
+    for person in &entry.contributors {
+        write_person(writer, "contributor", person)?;
+    }
+    for link in &entry.links {
+        write_link(writer, link)?;
+    }
+    for category in &entry.categories {
+        write_category(writer, category)?;
+    }
+
+    writer.write_event(Event::End(BytesEnd::new("entry")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_feed() -> AtomFeed {
+        AtomFeed::new()
+            .id("urn:example:feed")
+            .title("Example")
+            .updated("2026-06-27T00:00:00Z")
+            .author_name("Tester")
+    }
+
+    #[test]
+    fn validate_rejects_missing_required_fields() {
+        let feed = AtomFeed::new();
+        let err = feed.validate().unwrap_err();
+        let RssError::ValidationErrors(msgs) = err else {
+            panic!("expected ValidationErrors");
+        };
+        assert!(msgs.iter().any(|m| m == "feed.id is missing"));
+        assert!(msgs.iter().any(|m| m == "feed.title is missing"));
+        assert!(msgs.iter().any(|m| m == "feed.updated is missing"));
+    }
+
+    #[test]
+    fn validate_rejects_non_rfc3339_updated() {
+        let feed = AtomFeed::new()
+            .id("urn:example:feed")
+            .title("Example")
+            .updated("yesterday afternoon")
+            .author_name("Tester");
+        let err = feed.validate().unwrap_err();
+        let RssError::ValidationErrors(msgs) = err else {
+            panic!("expected ValidationErrors");
+        };
+        assert!(msgs.iter().any(|m| m.starts_with(
+            "feed.updated is not a valid RFC 3339 timestamp"
+        )));
+    }
+
+    #[test]
+    fn entry_inherits_feed_author_requirement() {
+        let feed = AtomFeed::new()
+            .id("urn:example:feed")
+            .title("Example")
+            .updated("2026-06-27T00:00:00Z")
+            .add_entry(
+                AtomEntry::new()
+                    .id("urn:example:entry-1")
+                    .title("Entry 1")
+                    .updated("2026-06-27T00:00:00Z"),
+            );
+        let err = feed.validate().unwrap_err();
+        let RssError::ValidationErrors(msgs) = err else {
+            panic!("expected ValidationErrors");
+        };
+        assert!(msgs.iter().any(|m| m.contains("entry.0.author")));
+    }
+
+    #[test]
+    fn entry_validate_uses_unindexed_prefix() {
+        let entry = AtomEntry::new();
+        let err = entry.validate().unwrap_err();
+        let RssError::ValidationErrors(msgs) = err else {
+            panic!("expected ValidationErrors");
+        };
+        assert!(msgs.iter().any(|m| m == "entry.id is missing"));
+        assert!(msgs.iter().any(|m| m == "entry.title is missing"));
+        assert!(msgs.iter().any(|m| m == "entry.updated is missing"));
+    }
+
+    #[test]
+    fn generate_minimal_feed_emits_required_elements() {
+        let xml = generate_atom(&minimal_feed()).unwrap();
+        assert!(xml
+            .contains(r#"<feed xmlns="http://www.w3.org/2005/Atom">"#));
+        assert!(xml.contains("<id>urn:example:feed</id>"));
+        assert!(xml.contains("<title>Example</title>"));
+        assert!(xml.contains("<updated>2026-06-27T00:00:00Z</updated>"));
+        assert!(xml.contains("<author>"));
+        assert!(xml.contains("<name>Tester</name>"));
+    }
+
+    #[test]
+    fn generate_feed_with_language_sets_xml_lang() {
+        let feed = minimal_feed().language("en-US");
+        let xml = generate_atom(&feed).unwrap();
+        assert!(xml.contains(r#"xml:lang="en-US""#));
+    }
+
+    #[test]
+    fn generate_feed_with_self_link_emits_rel_self() {
+        let feed =
+            minimal_feed().self_link("https://example.com/atom.xml");
+        let xml = generate_atom(&feed).unwrap();
+        assert!(xml.contains(
+            r#"<link href="https://example.com/atom.xml" rel="self"/>"#
+        ));
+    }
+
+    #[test]
+    fn generate_entry_with_enclosure_emits_rel_enclosure() {
+        let feed = minimal_feed().add_entry(
+            AtomEntry::new()
+                .id("urn:example:ep-1")
+                .title("Episode 1")
+                .updated("2026-06-27T00:00:00Z")
+                .summary("Pilot episode")
+                .add_enclosure(
+                    "https://example.com/ep-1.mp3",
+                    "audio/mpeg",
+                    12_345_678,
+                ),
+        );
+        let xml = generate_atom(&feed).unwrap();
+        assert!(xml.contains(r#"rel="enclosure""#));
+        assert!(xml.contains(r#"type="audio/mpeg""#));
+        assert!(xml.contains(r#"length="12345678""#));
+    }
+
+    #[test]
+    fn generate_entry_with_html_content_sets_type_html() {
+        let feed = minimal_feed().add_entry(
+            AtomEntry::new()
+                .id("urn:example:post-1")
+                .title("Post 1")
+                .updated("2026-06-27T00:00:00Z")
+                .content_html("<p>Hello</p>"),
+        );
+        let xml = generate_atom(&feed).unwrap();
+        assert!(xml.contains(r#"<content type="html">"#));
+        // The HTML payload must be escaped — the angle brackets in <p>
+        // become entities so the Atom document stays well-formed.
+        assert!(xml.contains("&lt;p&gt;Hello&lt;/p&gt;"));
+    }
+
+    #[test]
+    fn detect_feed_format_classifies_correctly() {
+        let rss = r#"<?xml version="1.0"?><rss version="2.0"><channel/></rss>"#;
+        let atom = r#"<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><id/></feed>"#;
+        let rdf = r#"<?xml version="1.0"?><rdf:RDF xmlns:rdf="..."><channel/></rdf:RDF>"#;
+        let other = r#"<?xml version="1.0"?><html><body/></html>"#;
+        let unparseable = "not xml at all";
+        assert_eq!(detect_feed_format(rss), FeedFormat::Rss);
+        assert_eq!(detect_feed_format(atom), FeedFormat::Atom);
+        assert_eq!(detect_feed_format(rdf), FeedFormat::RssRdf);
+        assert_eq!(detect_feed_format(other), FeedFormat::Unknown);
+        assert_eq!(
+            detect_feed_format(unparseable),
+            FeedFormat::Unknown
+        );
+    }
+
+    #[test]
+    fn detect_treats_feed_without_atom_namespace_as_unknown() {
+        let no_ns = r#"<?xml version="1.0"?><feed><id/></feed>"#;
+        assert_eq!(detect_feed_format(no_ns), FeedFormat::Unknown);
+    }
+
+    #[test]
+    fn round_trip_detect_after_generate() {
+        let xml = generate_atom(&minimal_feed()).unwrap();
+        assert_eq!(detect_feed_format(&xml), FeedFormat::Atom);
+    }
+
+    #[test]
+    fn special_characters_are_escaped_in_text_payloads() {
+        let feed = AtomFeed::new()
+            .id("urn:example:feed")
+            .title("A & B < C > D")
+            .updated("2026-06-27T00:00:00Z")
+            .author_name("Tester");
+        let xml = generate_atom(&feed).unwrap();
+        assert!(xml.contains("<title>A &amp; B &lt; C &gt; D</title>"));
+    }
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -334,30 +334,36 @@ impl RssData {
     pub fn validate(&self) -> Result<()> {
         let mut errors = Vec::new();
 
+        // Issue #34: prefix errors with `channel.` so downstream
+        // tooling can distinguish channel-level failures from
+        // per-item failures.
         if self.title.is_empty() {
-            errors.push("Title is missing".to_string());
+            errors.push("channel.title is missing".to_string());
         }
 
         if self.link.is_empty() {
-            errors.push("Link is missing".to_string());
+            errors.push("channel.link is missing".to_string());
         } else if let Err(e) = validate_url(&self.link) {
-            errors.push(format!("Invalid link: {e}"));
+            // RSS 2.0 §5.1 requires the channel link to be an
+            // absolute browser-followable URL. Keep `validate_url`
+            // (http/https only) for the channel pass.
+            errors.push(format!("Invalid channel.link: {e}"));
         }
 
         if self.description.is_empty() {
-            errors.push("Description is missing".to_string());
+            errors.push("channel.description is missing".to_string());
         }
 
         // Check category length
         if self.category.len() > MAX_GENERAL_LENGTH {
             return Err(RssError::InvalidInput(format!(
-            "Category exceeds maximum allowed length of {MAX_GENERAL_LENGTH} characters"
+            "channel.category exceeds maximum allowed length of {MAX_GENERAL_LENGTH} characters"
         )));
         }
 
         if !self.pub_date.is_empty() {
             if let Err(e) = parse_date(&self.pub_date) {
-                errors.push(format!("Invalid publication date: {e}"));
+                errors.push(format!("Invalid channel.pub_date: {e}"));
             }
         }
 
@@ -661,18 +667,23 @@ impl RssItem {
     pub fn validate(&self) -> Result<()> {
         let mut errors = Vec::new();
 
+        // Issue #34: prefix errors with `item.` so downstream tooling
+        // can distinguish per-item failures from channel-level ones.
         if self.title.is_empty() {
-            errors.push("Title is missing".to_string());
+            errors.push("item.title is missing".to_string());
         }
 
         if self.link.is_empty() {
-            errors.push("Link is missing".to_string());
-        } else if let Err(e) = validate_url(&self.link) {
-            errors.push(format!("Invalid link: {e}"));
+            errors.push("item.link is missing".to_string());
+        } else if let Err(e) = validate_link_field(&self.link) {
+            // RSS 2.0 §5.7 allows item links to be relative — use the
+            // lenient `validate_link_field` instead of the strict
+            // `validate_url` we apply to channel.link.
+            errors.push(format!("Invalid item.link: {e}"));
         }
 
         if self.description.is_empty() {
-            errors.push("Description is missing".to_string());
+            errors.push("item.description is missing".to_string());
         }
 
         // Add more field validations as needed...
@@ -815,6 +826,46 @@ pub fn validate_url(url: &str) -> Result<()> {
     Ok(())
 }
 
+/// Validates a value used as an item-level link field.
+///
+/// Per RSS 2.0 §5.7 item-level link URLs may be relative. This helper
+/// accepts:
+///
+///   * absolute URLs (any scheme that `url::Url` parses), e.g.
+///     `https://example.com/post`
+///   * root-relative paths starting with `/`, e.g. `/tags/`
+///   * bare paths without a leading slash, e.g. `articles/foo.html`
+///
+/// Rejects:
+///
+///   * the empty string (caller should check `is_empty()` first)
+///   * any string containing whitespace or ASCII control characters —
+///     those would round-trip into the rendered RSS XML and break
+///     well-formedness or feed-reader parsing.
+///
+/// # Errors
+///
+/// Returns `RssError::InvalidUrl` with a descriptive message when the
+/// input contains whitespace or control characters, or is empty.
+pub fn validate_link_field(value: &str) -> Result<()> {
+    if value.is_empty() {
+        return Err(RssError::InvalidUrl(
+            "empty link is not a valid relative or absolute URL"
+                .to_string(),
+        ));
+    }
+    if value.chars().any(|c| c.is_whitespace() || c.is_control()) {
+        return Err(RssError::InvalidUrl(format!(
+            "link contains whitespace or control characters: {value:?}"
+        )));
+    }
+    // Anything else — absolute URL OR relative path — is accepted.
+    // `Url::parse` would reject relative paths because there's no
+    // base, so we don't call it here. RSS 2.0 §5.7 explicitly allows
+    // both shapes for item links.
+    Ok(())
+}
+
 /// Parses a date string into a `DateTime`.
 ///
 /// # Arguments
@@ -952,8 +1003,8 @@ mod tests {
         let result = invalid_rss_data.validate();
         assert!(result.is_err());
         if let Err(RssError::ValidationErrors(errors)) = result {
-            assert!(errors.iter().any(|e| e.contains("Invalid link")),
-                "Expected an error containing 'Invalid link', but got: {errors:?}");
+            assert!(errors.iter().any(|e| e.contains("Invalid channel.link")),
+                "Expected an error containing 'Invalid channel.link', but got: {errors:?}");
         } else {
             panic!("Expected ValidationErrors");
         }
@@ -1051,7 +1102,10 @@ mod tests {
 
         if let Err(RssError::ValidationErrors(errors)) = result {
             assert_eq!(errors.len(), 1); // Adjust to expect 1 error if only one is returned
-            assert!(errors.contains(&"Link is missing".to_string())); // Adjust to the actual error returned
+            assert!(
+                errors.contains(&"item.link is missing".to_string()),
+                "expected `item.link is missing`, got: {errors:?}"
+            );
         } else {
             panic!("Expected ValidationErrors");
         }
@@ -1386,8 +1440,8 @@ mod tests {
             assert!(
                 errors
                     .iter()
-                    .any(|e| e.contains("Invalid publication date")),
-                "Expected 'Invalid publication date' error, got: {errors:?}"
+                    .any(|e| e.contains("Invalid channel.pub_date")),
+                "Expected 'Invalid channel.pub_date' error, got: {errors:?}"
             );
         } else {
             panic!("Expected ValidationErrors");
@@ -1396,17 +1450,20 @@ mod tests {
 
     #[test]
     fn test_rss_item_validate_invalid_link() {
+        // Issue #34: relative URLs are now allowed for item links
+        // (RSS 2.0 §5.7). Only whitespace / control chars are
+        // rejected because they break XML well-formedness.
         let item = RssItem::new()
             .title("Item")
-            .link("not-a-valid-url")
+            .link("not a valid url with spaces")
             .description("Desc");
 
         let result = item.validate();
         assert!(result.is_err());
         if let Err(RssError::ValidationErrors(errors)) = result {
             assert!(
-                errors.iter().any(|e| e.contains("Invalid link")),
-                "Expected 'Invalid link' error, got: {errors:?}"
+                errors.iter().any(|e| e.contains("Invalid item.link")),
+                "Expected `Invalid item.link` error, got: {errors:?}"
             );
         } else {
             panic!("Expected ValidationErrors");
@@ -1539,5 +1596,68 @@ mod tests {
     fn test_parse_date_invalid() {
         let result = parse_date("completely invalid date");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rss_item_accepts_relative_link() {
+        // Regression for sebastienrousseau/rssgen#34.
+        // RSS 2.0 §5.7 allows item-level relative URLs. Root-relative
+        // and bare-path forms must both pass.
+        for link in ["/tags/", "articles/foo.html", "post.html"] {
+            let item = RssItem::new()
+                .title("Item")
+                .link(link)
+                .description("Desc");
+            assert!(
+                item.validate().is_ok(),
+                "expected relative link {link:?} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rss_data_still_rejects_relative_link() {
+        // Channel-level link (RSS 2.0 §5.1) must be absolute.
+        // Regression for sebastienrousseau/rssgen#34: don't accidentally
+        // relax this when fixing the item-level rule.
+        let data = RssData::new(None)
+            .title("Channel")
+            .link("/tags/")
+            .description("Desc");
+        let result = data.validate();
+        assert!(
+            result.is_err(),
+            "channel.link `/tags/` must be rejected"
+        );
+        if let Err(RssError::ValidationErrors(errors)) = result {
+            assert!(
+                errors
+                    .iter()
+                    .any(|e| e.contains("Invalid channel.link")),
+                "expected channel-prefixed error, got: {errors:?}"
+            );
+        } else {
+            panic!("expected ValidationErrors");
+        }
+    }
+
+    #[test]
+    fn test_validate_link_field_rejects_whitespace_and_control() {
+        // Whitespace / control characters break XML well-formedness
+        // even though they pass URL parsing.
+        assert!(validate_link_field("/path with space").is_err());
+        assert!(validate_link_field("foo\tbar").is_err());
+        assert!(validate_link_field("\u{0007}beep").is_err());
+        assert!(validate_link_field("").is_err());
+    }
+
+    #[test]
+    fn test_validate_link_field_accepts_absolute_and_relative() {
+        assert!(validate_link_field("https://example.com/post").is_ok());
+        assert!(validate_link_field("http://example.com/").is_ok());
+        assert!(validate_link_field("/tags/").is_ok());
+        assert!(validate_link_field("articles/foo.html").is_ok());
+        // Non-http schemes are fine for items (atom, mailto, etc.).
+        assert!(validate_link_field("mailto:hi@example.com").is_ok());
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -9,10 +9,9 @@
 //! utility functions for URL validation and date parsing.
 
 use crate::{
-    error::{Result, RssError},
+    error::{Result, RssError, ValidationError},
     MAX_FEED_SIZE, MAX_GENERAL_LENGTH,
 };
-use dtt::datetime::DateTime;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
@@ -332,26 +331,38 @@ impl RssData {
     ///
     /// Additionally, it can return an error if the link format is invalid or the publication date cannot be parsed.
     pub fn validate(&self) -> Result<()> {
-        let mut errors = Vec::new();
+        let mut errors: Vec<ValidationError> = Vec::new();
 
         // Issue #34: prefix errors with `channel.` so downstream
         // tooling can distinguish channel-level failures from
         // per-item failures.
         if self.title.is_empty() {
-            errors.push("channel.title is missing".to_string());
+            errors.push(ValidationError::new(
+                "channel.title",
+                "channel.title is missing",
+            ));
         }
 
         if self.link.is_empty() {
-            errors.push("channel.link is missing".to_string());
+            errors.push(ValidationError::new(
+                "channel.link",
+                "channel.link is missing",
+            ));
         } else if let Err(e) = validate_url(&self.link) {
             // RSS 2.0 §5.1 requires the channel link to be an
             // absolute browser-followable URL. Keep `validate_url`
             // (http/https only) for the channel pass.
-            errors.push(format!("Invalid channel.link: {e}"));
+            errors.push(ValidationError::new(
+                "channel.link",
+                format!("Invalid channel.link: {e}"),
+            ));
         }
 
         if self.description.is_empty() {
-            errors.push("channel.description is missing".to_string());
+            errors.push(ValidationError::new(
+                "channel.description",
+                "channel.description is missing",
+            ));
         }
 
         // Check category length
@@ -363,7 +374,10 @@ impl RssData {
 
         if !self.pub_date.is_empty() {
             if let Err(e) = parse_date(&self.pub_date) {
-                errors.push(format!("Invalid channel.pub_date: {e}"));
+                errors.push(ValidationError::new(
+                    "channel.pub_date",
+                    format!("Invalid channel.pub_date: {e}"),
+                ));
             }
         }
 
@@ -665,28 +679,38 @@ impl RssItem {
     ///
     /// Additionally, it can return an error if any of the custom validation rules are violated (e.g., maximum length for certain fields).
     pub fn validate(&self) -> Result<()> {
-        let mut errors = Vec::new();
+        let mut errors: Vec<ValidationError> = Vec::new();
 
         // Issue #34: prefix errors with `item.` so downstream tooling
         // can distinguish per-item failures from channel-level ones.
         if self.title.is_empty() {
-            errors.push("item.title is missing".to_string());
+            errors.push(ValidationError::new(
+                "item.title",
+                "item.title is missing",
+            ));
         }
 
         if self.link.is_empty() {
-            errors.push("item.link is missing".to_string());
+            errors.push(ValidationError::new(
+                "item.link",
+                "item.link is missing",
+            ));
         } else if let Err(e) = validate_link_field(&self.link) {
             // RSS 2.0 §5.7 allows item links to be relative — use the
             // lenient `validate_link_field` instead of the strict
             // `validate_url` we apply to channel.link.
-            errors.push(format!("Invalid item.link: {e}"));
+            errors.push(ValidationError::new(
+                "item.link",
+                format!("Invalid item.link: {e}"),
+            ));
         }
 
         if self.description.is_empty() {
-            errors.push("item.description is missing".to_string());
+            errors.push(ValidationError::new(
+                "item.description",
+                "item.description is missing",
+            ));
         }
-
-        // Add more field validations as needed...
 
         if !errors.is_empty() {
             return Err(RssError::ValidationErrors(errors));
@@ -695,18 +719,16 @@ impl RssItem {
         Ok(())
     }
 
-    /// Parses the `pub_date` string into a `DateTime` object.
+    /// Parses the `pub_date` string into a [`time::OffsetDateTime`].
     ///
-    /// # Returns
-    ///
-    /// * `Ok(DateTime)` if the date is valid and successfully parsed.
-    /// * `Err(RssError)` if the date is invalid or cannot be parsed.
+    /// Delegates to [`parse_date`], which accepts both RFC 2822
+    /// and ISO 8601 inputs.
     ///
     /// # Errors
     ///
-    /// This function returns an `Err(RssError)` if the `pub_date` is invalid or
-    /// cannot be parsed into a `DateTime` object.
-    pub fn pub_date_parsed(&self) -> Result<DateTime> {
+    /// Returns [`RssError::DateParseError`] when the `pub_date` field
+    /// matches neither RFC 2822 nor ISO 8601.
+    pub fn pub_date_parsed(&self) -> Result<OffsetDateTime> {
         parse_date(&self.pub_date)
     }
 
@@ -866,40 +888,33 @@ pub fn validate_link_field(value: &str) -> Result<()> {
     Ok(())
 }
 
-/// Parses a date string into a `DateTime`.
+/// Parses a date string into a [`time::OffsetDateTime`].
+///
+/// Accepts both RFC 2822 (the historical RSS 2.0 wire format —
+/// `Mon, 01 Jan 2024 00:00:00 GMT` / `… +0000` / `… +0530`) and ISO 8601
+/// (`2024-01-01T00:00:00Z`, used by Atom and Dublin Core). The previous
+/// implementation collapsed every successfully-parsed date to a UTC
+/// sentinel; this revision returns the actual parsed value so callers can
+/// inspect the timezone offset and the exact instant.
 ///
 /// # Arguments
 ///
 /// * `date_str` - A string slice that holds the date to parse.
 ///
-/// # Returns
-///
-/// * `Ok(DateTime)` if the date is valid and successfully parsed.
-/// * `Err(RssError)` if the date is invalid or cannot be parsed.
-///
 /// # Errors
 ///
-/// This function returns an `Err(RssError::DateParseError)` if the date cannot
-/// be parsed into a valid `DateTime`.
-///
-/// # Panics
-///
-/// This function will panic if the "UTC" time zone is invalid, but this is
-/// highly unlikely as "UTC" is always valid.
-pub fn parse_date(date_str: &str) -> Result<DateTime> {
-    if OffsetDateTime::parse(date_str, &Rfc2822).is_ok() {
-        return Ok(
-            DateTime::new_with_tz("UTC").expect("UTC is always valid")
-        );
+/// Returns [`RssError::DateParseError`] when the input matches neither
+/// RFC 2822 nor ISO 8601.
+pub fn parse_date(date_str: &str) -> Result<OffsetDateTime> {
+    if let Ok(parsed) = OffsetDateTime::parse(date_str, &Rfc2822) {
+        return Ok(parsed);
     }
 
-    if OffsetDateTime::parse(date_str, &Iso8601::DEFAULT).is_ok() {
-        return Ok(
-            DateTime::new_with_tz("UTC").expect("UTC is always valid")
-        );
+    if let Ok(parsed) =
+        OffsetDateTime::parse(date_str, &Iso8601::DEFAULT)
+    {
+        return Ok(parsed);
     }
-
-    // Handle custom parsing logic here...
 
     Err(RssError::DateParseError(date_str.to_string()))
 }
@@ -1003,8 +1018,9 @@ mod tests {
         let result = invalid_rss_data.validate();
         assert!(result.is_err());
         if let Err(RssError::ValidationErrors(errors)) = result {
-            assert!(errors.iter().any(|e| e.contains("Invalid channel.link")),
-                "Expected an error containing 'Invalid channel.link', but got: {errors:?}");
+            assert!(errors.iter().any(|e| e.field == "channel.link"
+                && e.message.contains("Invalid channel.link")),
+                "Expected a structured ValidationError on `channel.link`, got: {errors:?}");
         } else {
             panic!("Expected ValidationErrors");
         }
@@ -1101,9 +1117,10 @@ mod tests {
         assert!(result.is_err());
 
         if let Err(RssError::ValidationErrors(errors)) = result {
-            assert_eq!(errors.len(), 1); // Adjust to expect 1 error if only one is returned
+            assert_eq!(errors.len(), 1);
             assert!(
-                errors.contains(&"item.link is missing".to_string()),
+                errors.iter().any(|e| e.field == "item.link"
+                    && e.message == "item.link is missing"),
                 "expected `item.link is missing`, got: {errors:?}"
             );
         } else {
@@ -1438,10 +1455,9 @@ mod tests {
         assert!(result.is_err());
         if let Err(RssError::ValidationErrors(errors)) = result {
             assert!(
-                errors
-                    .iter()
-                    .any(|e| e.contains("Invalid channel.pub_date")),
-                "Expected 'Invalid channel.pub_date' error, got: {errors:?}"
+                errors.iter().any(|e| e.field == "channel.pub_date"
+                    && e.message.contains("Invalid channel.pub_date")),
+                "Expected structured `channel.pub_date` error, got: {errors:?}"
             );
         } else {
             panic!("Expected ValidationErrors");
@@ -1462,8 +1478,9 @@ mod tests {
         assert!(result.is_err());
         if let Err(RssError::ValidationErrors(errors)) = result {
             assert!(
-                errors.iter().any(|e| e.contains("Invalid item.link")),
-                "Expected `Invalid item.link` error, got: {errors:?}"
+                errors.iter().any(|e| e.field == "item.link"
+                    && e.message.contains("Invalid item.link")),
+                "Expected structured `item.link` error, got: {errors:?}"
             );
         } else {
             panic!("Expected ValidationErrors");
@@ -1631,10 +1648,9 @@ mod tests {
         );
         if let Err(RssError::ValidationErrors(errors)) = result {
             assert!(
-                errors
-                    .iter()
-                    .any(|e| e.contains("Invalid channel.link")),
-                "expected channel-prefixed error, got: {errors:?}"
+                errors.iter().any(|e| e.field == "channel.link"
+                    && e.message.contains("Invalid channel.link")),
+                "expected channel-prefixed structured error, got: {errors:?}"
             );
         } else {
             panic!("expected ValidationErrors");

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,8 +49,14 @@ pub enum RssError {
     UnknownElement(String),
 
     /// Error for validation errors.
+    ///
+    /// Carries a `Vec<ValidationError>` rather than `Vec<String>` so callers
+    /// can programmatically inspect the offending `field` rather than parse
+    /// human-readable strings. The wrapped `ValidationError::Display` impl
+    /// formats as the bare `message` (e.g. `channel.title is missing`),
+    /// matching the string format used in earlier releases.
     #[error("Validation errors: {0:?}")]
-    ValidationErrors(Vec<String>),
+    ValidationErrors(Vec<ValidationError>),
 
     /// Error for date sort errors.
     #[error("Date sort error: {0:?}")]
@@ -82,14 +88,43 @@ pub enum RssError {
 }
 
 /// Represents a specific validation error.
-#[derive(Debug, Error)]
+///
+/// `field` identifies the offending element using a dotted path
+/// (`channel.title`, `item.0.link`, `feed.id`, `entry.2.updated`, …) so
+/// downstream tooling can dispatch on the field without parsing strings.
+/// `message` is the full human-readable error text and is what
+/// [`std::fmt::Display`] writes — preserving the bare-string format that previous
+/// releases of this crate emitted as the [`RssError::ValidationErrors`]
+/// payload.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
-#[error("Validation error: {message}")]
+#[error("{message}")]
 pub struct ValidationError {
-    /// The field that failed validation.
+    /// The dotted path identifying the field that failed validation.
     pub field: String,
-    /// The error message.
+    /// The full human-readable error text. Read via `Display` /
+    /// `to_string()`; matches the string format used in
+    /// pre-v0.0.6 releases.
     pub message: String,
+}
+
+impl ValidationError {
+    /// Constructs a [`ValidationError`].
+    ///
+    /// `field` should be the dotted path (e.g. `"channel.title"`);
+    /// `message` is the full human-readable error text and is what
+    /// [`std::fmt::Display`] writes back out — keeping the bare-string format used
+    /// by earlier releases of this crate.
+    #[must_use]
+    pub fn new<F: Into<String>, M: Into<String>>(
+        field: F,
+        message: M,
+    ) -> Self {
+        Self {
+            field: field.into(),
+            message: message.into(),
+        }
+    }
 }
 
 /// Represents a specific date sorting error.
@@ -341,14 +376,18 @@ mod tests {
 
     #[test]
     fn test_validation_error() {
-        let error = ValidationError {
-            field: "some_field".to_string(),
-            message: "Invalid field".to_string(),
-        };
-        assert_eq!(
-            error.to_string(),
-            "Validation error: Invalid field"
+        // v0.0.6: Display writes the bare `message`, not the previous
+        // "Validation error: …" prefix — callers that compared the
+        // string against `e.to_string()` now see the same strings the
+        // crate produced as `Vec<String>` entries pre-v0.0.6, which is
+        // what the property tests in tests/property_tests.rs assert.
+        let error = ValidationError::new(
+            "channel.title",
+            "channel.title is missing",
         );
+        assert_eq!(error.to_string(), "channel.title is missing");
+        assert_eq!(error.field, "channel.title");
+        assert_eq!(error.message, "channel.title is missing");
     }
 
     #[test]
@@ -406,16 +445,39 @@ mod tests {
     #[test]
     fn test_validation_errors() {
         let validation_errors = vec![
-            "Title is missing".to_string(),
-            "Invalid pub date".to_string(),
+            ValidationError::new(
+                "channel.title",
+                "channel.title is missing",
+            ),
+            ValidationError::new(
+                "channel.pub_date",
+                "Invalid channel.pub_date: 2026/06/28",
+            ),
         ];
         let rss_error =
             RssError::ValidationErrors(validation_errors.clone());
 
+        // Display of ValidationError is the bare `message` — matches the
+        // string format pre-v0.0.6 callers were used to.
         assert_eq!(
-            format!("{rss_error}"),
-            format!("Validation errors: {:?}", validation_errors)
+            validation_errors[0].to_string(),
+            "channel.title is missing"
         );
+        // The wrapping RssError formats the Vec via its Debug impl so
+        // both the field and the message are surfaced.
+        let rendered = format!("{rss_error}");
+        assert!(rendered.contains("channel.title"));
+        assert!(rendered.contains("Invalid channel.pub_date"));
+    }
+
+    #[test]
+    fn test_validation_error_field_is_accessible() {
+        let err = ValidationError::new(
+            "item.0.link",
+            "item.0.link is missing",
+        );
+        assert_eq!(err.field, "item.0.link");
+        assert_eq!(err.to_string(), "item.0.link is missing");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@
 #![deny(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 
+/// Atom 1.0 feed generation, validation, and feed-format detection.
+pub mod atom;
 /// Contains the main types and data structures used to represent RSS feeds.
 pub mod data;
 /// Defines error types used throughout the library.
@@ -31,6 +33,10 @@ pub mod parser;
 /// Provides utilities for validating RSS feeds.
 pub mod validator;
 
+pub use atom::{
+    detect_feed_format, generate_atom, AtomEntry, AtomFeed, AtomLink,
+    AtomPerson, AtomTextType, FeedFormat,
+};
 pub use data::{RssData, RssItem, RssVersion};
 pub use error::{Result, RssError};
 pub use generator::generate_rss;
@@ -145,6 +151,10 @@ pub fn quick_rss(
 
 /// Prelude module for convenient importing of common types and functions.
 pub mod prelude {
+    pub use crate::atom::{
+        detect_feed_format, generate_atom, AtomEntry, AtomFeed,
+        AtomLink, AtomPerson, AtomTextType, FeedFormat,
+    };
     pub use crate::data::{RssData, RssItem, RssVersion};
     pub use crate::error::{Result, RssError};
     pub use crate::generate_rss;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@
 
 #![doc = include_str!("../README.md")]
 #![doc(
-    html_favicon_url = "https://kura.pro/rssgen/images/favicon.ico",
-    html_logo_url = "https://kura.pro/rssgen/images/logos/rssgen.svg",
+    html_favicon_url = "https://cloudcdn.pro/rssgen/v1/favicon.ico",
+    html_logo_url = "https://cloudcdn.pro/rssgen/v1/logos/rssgen.svg",
     html_root_url = "https://docs.rs/rss-gen"
 )]
 #![crate_name = "rss_gen"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub use atom::{
     AtomPerson, AtomTextType, FeedFormat,
 };
 pub use data::{RssData, RssItem, RssVersion};
-pub use error::{Result, RssError};
+pub use error::{Result, RssError, ValidationError};
 pub use generator::generate_rss;
 pub use parser::parse_rss;
 
@@ -156,7 +156,7 @@ pub mod prelude {
         AtomLink, AtomPerson, AtomTextType, FeedFormat,
     };
     pub use crate::data::{RssData, RssItem, RssVersion};
-    pub use crate::error::{Result, RssError};
+    pub use crate::error::{Result, RssError, ValidationError};
     pub use crate::generate_rss;
     pub use crate::parse_rss;
     pub use crate::quick_rss;

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -599,7 +599,11 @@ mod tests {
         validator.validate_rss_data(&mut errors);
 
         assert!(!errors.is_empty());
-        assert!(errors[0].message.contains("Title is missing"));
+        assert!(
+            errors[0].message.contains("channel.title is missing"),
+            "expected `channel.title is missing`, got: {:?}",
+            errors[0].message
+        );
     }
 
     #[test]

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -6,9 +6,12 @@
 //! This module provides functionality to validate RSS feeds, ensuring they
 //! conform to the specified RSS version standards and contain valid data.
 
-use crate::data::{RssData, RssVersion};
+use crate::data::{
+    parse_date as parse_rss_date, validate_link_field, RssData,
+    RssVersion,
+};
 use crate::error::{Result, RssError, ValidationError};
-use dtt::datetime::DateTime;
+use time::OffsetDateTime;
 use url::Url;
 
 /// Maximum allowed length for URL strings
@@ -60,9 +63,11 @@ impl<'a> RssFeedValidator<'a> {
         if errors.is_empty() {
             Ok(())
         } else {
-            Err(RssError::ValidationErrors(
-                errors.into_iter().map(|e| e.to_string()).collect(),
-            ))
+            // Preserve the structured `ValidationError { field, message }`
+            // shape rather than flattening to `Vec<String>` — callers
+            // (CI gates, IDE integrations, JSON error responses) can
+            // now match on `e.field` instead of parsing strings.
+            Err(RssError::ValidationErrors(errors))
         }
     }
 
@@ -78,22 +83,31 @@ impl<'a> RssFeedValidator<'a> {
 
     /// Validates the overall structure of the RSS feed.
     fn validate_structure(&self, errors: &mut Vec<ValidationError>) {
-        Self::validate_url(&self.rss_data.link, "channel link", errors);
+        Self::validate_url(&self.rss_data.link, "channel.link", errors);
 
         for (index, item) in self.rss_data.items.iter().enumerate() {
-            Self::validate_url(
-                &item.link,
-                &format!("item[{index}] link"),
-                errors,
-            );
+            // RSS 2.0 §5.7 allows item links to be relative — and an
+            // <item> isn't required to have a <link> at all so long as
+            // it carries a <title> or <description>. Skip the strict
+            // absolute-URL check for empty links and delegate the
+            // populated case to `validate_link_field` so we stay
+            // aligned with `RssData::validate` / `RssItem::validate`.
+            if item.link.is_empty() {
+                continue;
+            }
+            if let Err(e) = validate_link_field(&item.link) {
+                errors.push(ValidationError::new(
+                    format!("item.{index}.link"),
+                    format!("Invalid item.{index}.link: {e}"),
+                ));
+            }
         }
 
         if self.rss_data.items.is_empty() {
-            errors.push(ValidationError {
-                field: "items".to_string(),
-                message: "RSS feed must contain at least one item"
-                    .to_string(),
-            });
+            errors.push(ValidationError::new(
+                "items",
+                "RSS feed must contain at least one item",
+            ));
         }
 
         self.validate_guids(errors);
@@ -105,13 +119,10 @@ impl<'a> RssFeedValidator<'a> {
         let mut guids = std::collections::HashSet::new();
         for item in &self.rss_data.items {
             if !guids.insert(&item.guid) {
-                errors.push(ValidationError {
-                    field: "guid".to_string(),
-                    message: format!(
-                        "Duplicate GUID found: {}",
-                        item.guid
-                    ),
-                });
+                errors.push(ValidationError::new(
+                    "guid",
+                    format!("Duplicate GUID found: {}", item.guid),
+                ));
             }
         }
     }
@@ -121,11 +132,10 @@ impl<'a> RssFeedValidator<'a> {
         if self.rss_data.version == RssVersion::RSS2_0
             && self.rss_data.atom_link.is_empty()
         {
-            errors.push(ValidationError {
-                field: "atom_link".to_string(),
-                message: "atom:link is required for RSS 2.0 feeds"
-                    .to_string(),
-            });
+            errors.push(ValidationError::new(
+                "atom_link",
+                "atom:link is required for RSS 2.0 feeds",
+            ));
         }
     }
 
@@ -133,10 +143,10 @@ impl<'a> RssFeedValidator<'a> {
     fn validate_items(&self, errors: &mut Vec<ValidationError>) {
         for (index, item) in self.rss_data.items.iter().enumerate() {
             if let Err(e) = item.validate() {
-                errors.push(ValidationError {
-                    field: format!("item[{index}]"),
-                    message: format!("Item validation failed: {e}"),
-                });
+                errors.push(ValidationError::new(
+                    format!("item[{index}]"),
+                    format!("Item validation failed: {e}"),
+                ));
             }
         }
     }
@@ -167,47 +177,29 @@ impl<'a> RssFeedValidator<'a> {
     ) {
         if !date_str.is_empty() {
             if let Err(e) = Self::parse_date(date_str) {
-                errors.push(ValidationError {
-                    field: field.to_string(),
-                    message: format!("Invalid date format: {e}"),
-                });
+                errors.push(ValidationError::new(
+                    field,
+                    format!("Invalid date format: {e}"),
+                ));
             }
         }
     }
 
-    /// Parses a date string into a `DateTime` object.
+    /// Parses a date string into a [`time::OffsetDateTime`].
     ///
-    /// # Arguments
-    ///
-    /// * `date_str` - The date string to parse.
-    ///
-    /// # Returns
-    ///
-    /// A `Result` containing the parsed `DateTime` object or an error if the parsing fails.
+    /// Delegates to [`crate::data::parse_date`], which accepts both
+    /// RFC 2822 (the historical RSS 2.0 wire format — any timezone is
+    /// accepted, including `+0000`, `+0530`, `EST`, etc.) and ISO 8601
+    /// (used by Atom and Dublin Core). The previous implementation
+    /// hard-required a literal `" GMT"` suffix, rejecting every
+    /// spec-compliant feed produced outside of GMT.
     ///
     /// # Errors
     ///
-    /// This function returns an `Err(RssError::DateParseError)` if the date format is invalid.
-    pub fn parse_date(date_str: &str) -> Result<DateTime> {
-        let rss_date_format = "[weekday repr:short], [day] [month repr:short] [year] [hour]:[minute]:[second]";
-        let date_without_gmt =
-            date_str.strip_suffix(" GMT").ok_or_else(|| {
-                RssError::DateParseError(format!(
-                    "Invalid date format (missing GMT): {date_str}"
-                ))
-            })?;
-
-        let date = DateTime::parse_custom_format(
-            date_without_gmt,
-            rss_date_format,
-        )
-        .map_err(|_| {
-            RssError::DateParseError(format!(
-                "Failed to parse date: {date_str}"
-            ))
-        })?;
-
-        Ok(date)
+    /// Returns [`RssError::DateParseError`] when the input matches
+    /// neither RFC 2822 nor ISO 8601.
+    pub fn parse_date(date_str: &str) -> Result<OffsetDateTime> {
+        parse_rss_date(date_str)
     }
 
     /// Validates version-specific requirements of the RSS feed.
@@ -353,14 +345,14 @@ mod tests {
         let result = validator.validate();
         assert!(result.is_err());
         if let Err(RssError::ValidationErrors(errors)) = result {
-            assert!(errors
-                .iter()
-                .any(|e| e.contains("atom:link is required")));
-            assert!(errors.iter().any(|e| e
-                .contains("RSS feed must contain at least one item")));
-            assert!(errors
-                .iter()
-                .any(|e| e.contains("Invalid date format")));
+            assert!(errors.iter().any(|e| e.field == "atom_link"
+                && e.message.contains("atom:link is required")));
+            assert!(errors.iter().any(|e| e.field == "items"
+                && e.message.contains(
+                    "RSS feed must contain at least one item"
+                )));
+            assert!(errors.iter().any(|e| e.field == "pubDate"
+                && e.message.contains("Invalid date format")));
         } else {
             panic!("Expected ValidationErrors");
         }
@@ -651,9 +643,7 @@ mod tests {
         validator.validate_dates(&mut errors);
 
         assert!(!errors.is_empty(), "Expected date validation errors");
-        assert!(errors
-            .iter()
-            .any(|e| e.field.contains("item[0].pubDate")));
+        assert!(errors.iter().any(|e| e.field == "item[0].pubDate"));
     }
 
     #[test]
@@ -683,7 +673,7 @@ mod tests {
         rss_data.add_item(
             RssItem::new()
                 .title("Item")
-                .link("not-a-valid-url")
+                .link("bad url with spaces")
                 .description("Desc")
                 .guid("guid1"),
         );
@@ -692,32 +682,101 @@ mod tests {
         let mut errors = Vec::new();
         validator.validate_structure(&mut errors);
 
-        assert!(errors
-            .iter()
-            .any(|e| e.field.contains("item[0] link")));
+        assert!(errors.iter().any(|e| e.field == "item.0.link"
+            && e.message.contains("Invalid item.0.link")));
     }
 
     #[test]
-    fn test_parse_date_missing_gmt_suffix() {
-        let result =
-            RssFeedValidator::parse_date("Mon, 01 Jan 2024 00:00:00");
-        assert!(result.is_err());
-        if let Err(RssError::DateParseError(msg)) = result {
-            assert!(msg.contains("missing GMT"));
-        } else {
-            panic!("Expected DateParseError");
-        }
+    fn test_validate_structure_allows_empty_item_link() {
+        // RSS 2.0 §5.7 — an <item> with a <title> and <description>
+        // does NOT require a <link>. Empty item.link must NOT fail
+        // structural validation. Regression: pre-v0.0.6 the validator
+        // called Url::parse("") which always errored.
+        let mut rss_data = RssData::new(Some(RssVersion::RSS2_0))
+            .title("Test Feed")
+            .link("https://example.com")
+            .description("A test feed")
+            .atom_link("https://example.com/feed.xml");
+
+        rss_data.add_item(
+            RssItem::new()
+                .title("Item")
+                .description("Body only — no link")
+                .guid("guid-no-link"),
+        );
+
+        let validator = RssFeedValidator::new(&rss_data);
+        let mut errors = Vec::new();
+        validator.validate_structure(&mut errors);
+
+        // The empty item.link must NOT have produced a structural error.
+        // The single item has index 0 — assert that no error fires
+        // against `item.0.link` specifically.
+        assert!(
+            !errors.iter().any(|e| e.field == "item.0.link"),
+            "empty item.link should be accepted, got: {errors:?}"
+        );
     }
 
     #[test]
-    fn test_parse_date_invalid_format_with_gmt() {
-        let result = RssFeedValidator::parse_date("not-a-date GMT");
-        assert!(result.is_err());
-        if let Err(RssError::DateParseError(msg)) = result {
-            assert!(msg.contains("Failed to parse date"));
-        } else {
-            panic!("Expected DateParseError");
-        }
+    fn test_validate_structure_allows_relative_item_link() {
+        // RSS 2.0 §5.7 also allows relative URLs at the item level.
+        let mut rss_data = RssData::new(Some(RssVersion::RSS2_0))
+            .title("Test Feed")
+            .link("https://example.com")
+            .description("A test feed")
+            .atom_link("https://example.com/feed.xml");
+
+        rss_data.add_item(
+            RssItem::new()
+                .title("Item")
+                .link("/tags/")
+                .description("Tag index")
+                .guid("guid-tags"),
+        );
+
+        let validator = RssFeedValidator::new(&rss_data);
+        let mut errors = Vec::new();
+        validator.validate_structure(&mut errors);
+        assert!(
+            !errors.iter().any(|e| e.field == "item.0.link"),
+            "relative item.link should be accepted, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_date_accepts_numeric_timezone_offset() {
+        // RFC 2822 / RFC 1123 allow numeric timezone offsets. The
+        // pre-v0.0.6 implementation hard-required the literal `" GMT"`
+        // suffix and rejected every offset-based date — a hard P0
+        // spec violation.
+        assert!(RssFeedValidator::parse_date(
+            "Sun, 28 Jun 2026 00:12:20 +0000"
+        )
+        .is_ok());
+        assert!(RssFeedValidator::parse_date(
+            "Sat, 27 Jun 2026 19:12:20 -0500"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_parse_date_accepts_iso8601() {
+        // Atom and Dublin Core date wire formats — must also flow
+        // through the same parse helper.
+        assert!(RssFeedValidator::parse_date("2026-06-28T00:12:20Z")
+            .is_ok());
+    }
+
+    #[test]
+    fn test_parse_date_no_longer_requires_gmt_suffix() {
+        // Regression: pre-v0.0.6 this string failed with "missing GMT".
+        // Today it's a perfectly compliant RFC 2822 instant and must
+        // round-trip.
+        assert!(RssFeedValidator::parse_date(
+            "Mon, 01 Jan 2024 00:00:00 +0000"
+        )
+        .is_ok());
     }
 
     #[test]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,0 +1,7 @@
+# cargo-vet audits authored by the rss-gen maintainers.
+#
+# New audits go here as `[[audits.<crate>]]` blocks. Run
+# `cargo vet certify <crate> safe-to-deploy` to interactively add an
+# entry after reviewing a crate's source.
+
+[criteria]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1,0 +1,35 @@
+# cargo-vet config — supply-chain audit baseline for rss-gen
+#
+# Imports trust roots from Mozilla, Google, Bytecode Alliance, Embark,
+# and ISRG. New audits live in audits.toml; exemptions for crates not
+# yet covered live below. Run `cargo vet check` locally; CI enforces.
+
+[cargo-vet]
+version = "0.10"
+
+[imports.bytecode-alliance]
+url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
+
+[imports.embark-studios]
+url = "https://raw.githubusercontent.com/EmbarkStudios/rust-ecosystem/main/audits.toml"
+
+[imports.google]
+url = "https://raw.githubusercontent.com/google/supply-chain/main/audits.toml"
+
+[imports.isrg]
+url = "https://raw.githubusercontent.com/divviup/libprio-rs/main/supply-chain/audits.toml"
+
+[imports.mozilla]
+url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
+
+[imports.zcash]
+url = "https://raw.githubusercontent.com/zcash/zcash/main/qa/supply-chain/audits.toml"
+
+# Policy: every direct dependency must reach `safe-to-deploy`. Crates
+# below are explicitly trusted by this project (typically because the
+# imported audit sets above don't yet cover them); each entry should
+# carry a comment justifying the exemption.
+
+[policy.rss-gen]
+audit-as-crates-io = false
+criteria = "safe-to-deploy"

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -223,8 +223,8 @@ mod regression_tests {
         assert!(result.is_err());
 
         if let Err(RssError::ValidationErrors(errors)) = result {
-            assert!(errors.len() >= 3); // Should have errors for title, link, description
             // Issue #34: errors now carry `channel.` / `item.` context prefix.
+            assert!(errors.len() >= 3);
             assert!(errors
                 .iter()
                 .any(|e| e.contains("channel.title is missing")));

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -224,16 +224,18 @@ mod regression_tests {
 
         if let Err(RssError::ValidationErrors(errors)) = result {
             // Issue #34: errors now carry `channel.` / `item.` context prefix.
+            // v0.0.6: ValidationErrors carries Vec<ValidationError> (was
+            // Vec<String>); field is the dotted path and message is the
+            // human-readable text — `Display` writes the bare message.
             assert!(errors.len() >= 3);
+            assert!(errors.iter().any(|e| e.field == "channel.title"
+                && e.message == "channel.title is missing"));
+            assert!(errors.iter().any(|e| e.field == "channel.link"
+                && e.message == "channel.link is missing"));
             assert!(errors
                 .iter()
-                .any(|e| e.contains("channel.title is missing")));
-            assert!(errors
-                .iter()
-                .any(|e| e.contains("channel.link is missing")));
-            assert!(errors
-                .iter()
-                .any(|e| e.contains("channel.description is missing")));
+                .any(|e| e.field == "channel.description"
+                    && e.message == "channel.description is missing"));
         } else {
             panic!("Expected ValidationErrors");
         }

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -224,15 +224,16 @@ mod regression_tests {
 
         if let Err(RssError::ValidationErrors(errors)) = result {
             assert!(errors.len() >= 3); // Should have errors for title, link, description
+            // Issue #34: errors now carry `channel.` / `item.` context prefix.
             assert!(errors
                 .iter()
-                .any(|e| e.contains("Title is missing")));
+                .any(|e| e.contains("channel.title is missing")));
             assert!(errors
                 .iter()
-                .any(|e| e.contains("Link is missing")));
+                .any(|e| e.contains("channel.link is missing")));
             assert!(errors
                 .iter()
-                .any(|e| e.contains("Description is missing")));
+                .any(|e| e.contains("channel.description is missing")));
         } else {
             panic!("Expected ValidationErrors");
         }


### PR DESCRIPTION
## Summary

Release branch for **rss-gen v0.0.6**. Lands the Atom 1.0 surface, restructures the validation error contract, closes the five P0/P1/P2 defects flagged in the technical audit, modernises the docs publish flow, and refreshes the README + CHANGELOG.

Seven commits, 17 files, +2 575 / −281 LOC. Full test suite (218 / 218) green, clippy under `clippy::pedantic` clean, fmt clean, strict rustdoc clean, **281 / 281 public items documented (100.0% coverage)**.

Closes **#24** (Atom 1.0 feed format support — P1) and **#34** (link validation rejects relative URLs and produces contextless errors).

---

## What's in this PR

### Features

- **Atom 1.0 feed format support** (closes #24). New `atom` module shipping `AtomFeed`, `AtomEntry`, `AtomPerson`, `AtomLink`, `AtomTextType`, plus the `generate_atom` serialiser. Covers RFC 4287 required elements at both feed and entry level (`id`, `title`, `updated`), media enclosures via `<link rel="enclosure" type="…" length="…">` (§4.2.7.2), plain-text and HTML payloads for `<summary>` / `<content>`, multiple authors and contributors, categories, `xml:lang`, icon / logo / rights / subtitle, RFC 3339 timestamp validation, and the §4.1.1 entry-author inheritance rule.
- **Format auto-detection** via `detect_feed_format(&str) -> FeedFormat` for dispatching between RSS (`<rss>` / `<rdf:RDF>`) and Atom (`<feed xmlns="…/Atom">`) inputs without parsing the body. Returns `FeedFormat::Unknown` for a bare `<feed>` without the Atom namespace, so a misclassified payload never silently flows into the Atom code path.

### Spec-correctness fixes (audit P0)

- **Validation errors carry context prefixes** (closes #34). Channel-level errors are prefixed with `channel.` and item-level errors with `item.`, replacing the bare `Link is missing` / `Title is missing` strings.
- **Relative item links are accepted** per RSS 2.0 §5.7 via the new `validate_link_field` helper. Absolute URLs, root-relative paths (`/tags/`), and bare paths (`articles/foo.html`) all pass; whitespace, control characters, and empty strings are rejected. Channel-level `link` retains absolute-URL strictness because the spec requires it.
- **`RssFeedValidator::parse_date` is no longer GMT-only.** The pre-v0.0.6 implementation hard-required a literal `" GMT"` suffix and rejected every spec-compliant feed produced outside of GMT (`+0000`, `+0530`, `EST`, …). It now delegates to `data::parse_date`, which accepts the full RFC 2822 grammar plus ISO 8601, aligning the standalone validator with the main `generate_rss` path.
- **`RssFeedValidator::validate_structure` no longer rejects empty or relative item links.** Pre-v0.0.6 the validator unconditionally fed every `item.link` to `Url::parse`, so any feed with description-only items always failed. RSS 2.0 §5.7 explicitly allows items to ship without a `<link>` so long as they carry a `<title>` or `<description>`; the structural pass now skips empty item links and delegates populated ones to `validate_link_field`.

### API / dependency cleanup (audit P1/P2)

- **`RssError::ValidationErrors` now carries `Vec<ValidationError>`** rather than `Vec<String>`. Each entry exposes structured `field` (a dotted path: `channel.title`, `item.0.link`, `feed.id`, `entry.2.updated`) and `message` properties so callers can dispatch on `field` without parsing strings. `Display` writes the bare `message`, so `e.to_string()` keeps the pre-v0.0.6 string format and `errors.iter().any(|e| e.to_string() == "channel.title is missing")` still works. `ValidationError` is now re-exported from the crate root and prelude.
- **Date stack consolidated on `time`.** Dropped the `dtt = "0.0"` dependency (experimental, no SemVer stability) and `commons = "euxis-commons"` (declared but never used in `src/`). `parse_date` / `RssItem::pub_date_parsed` now return `time::OffsetDateTime` directly rather than a `dtt::DateTime` UTC sentinel — callers see the actual parsed offset. `time` is declared with explicit `parsing`, `formatting`, and `macros` features.
- **Dropped the unused `serde_json` runtime dependency** — `grep -r serde_json src/` returned zero hits; it was pulled into every consumer's dep graph but never used by library code.
- **Removed the no-op `async = []` feature flag.** It gated zero `#[cfg]` code paths. Will return as a properly wired `tokio` / `async-write` feature in a follow-up.
- **Bumped `time` from `0.3.49` to `0.3.51`** (supersedes Dependabot PR #33). No API change.

### Documentation

- **README rewritten** against the `noyalib` reference style — Contents TOC, structured `Install` block with MSRV table, `Quick Start`, `Library Usage` with discrete subsections per capability (RSS generation, Atom 1.0, parsing, format detection, validation diagnostics, the `quick_rss` helper, `MAX_*` constants), `Modules` table, `Features` matrix, `Development`, `Security`, `Documentation`, `License`. Every fenced `rust` block is a self-contained runnable doctest wrapped in `fn main() -> Result<(), rss_gen::RssError>` with `?` propagation. The README is included as crate-root docs via `#![doc = include_str!("../README.md")]`, so all 18 doctests run on every `cargo test`.
- **CHANGELOG** updated under `[Unreleased]` with Added / Fixed / Changed / Performance / Tooling sections.
- **Logo + favicon** swapped from `kura.pro/rssgen/images/*` to `cloudcdn.pro/rssgen/v1/*` in README, TEMPLATE.md, and the `html_logo_url` / `html_favicon_url` crate attributes so docs.rs picks up the new CDN URLs.

### Tooling / DX

- **Benchmarks** (`benches/criterion.rs`) extended with `Generate Atom`, `Detect feed format`, and `Validate` groups (10 / 100 / 1000 items per fixture) alongside the existing `Generate RSS` / `Parse RSS` coverage.
- **Examples** added covering the new surface:
  - `examples/example_atom.rs` — multi-author + contributor Atom feed, text summary + HTML content, media enclosure, categories.
  - `examples/example_detect.rs` — root-element classifier across RSS 2.0, RSS 1.0 (RDF), Atom (namespaced), bare `<feed>`, and malformed input.
  - `examples/example_validation_errors.rs` — structured RSS + Atom error walks and the new RFC 2822 / ISO 8601 date acceptance.
  - `examples/stress_huge_feed.rs` — 50 000-item / -entry sanity benchmark with a self-asserted < 1 s / generate budget.
- **CI: docs publish migrated to GitHub Pages workflow mode** (`actions/upload-pages-artifact` + `actions/deploy-pages`), replacing the legacy `gh-pages` branch push. The `cname: doc.rssgen.co` input ensures the upload tarball carries a CNAME file so the custom domain stays bound across every deploy. Repository Pages source is switched to `build_type=workflow`; `gh-pages` branch is retired in the same release.

---

## Performance budget

`examples/stress_huge_feed --release` on an Apple M-series, 50 000 items / entries:

| Stage | Wall-clock | Output size |
| :--- | ---: | ---: |
| RSS `generate_rss` | **15 ms** | 14.0 MiB |
| Atom `generate_atom` | **114 ms** | 8.7 MiB |
| `detect_feed_format` × 2 docs | **7 µs** | 22.9 MiB combined |

All stages within the < 1 s / generate budget by 10×–100×.

---

## Quality bars

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean under `#![deny(clippy::all, clippy::cargo, clippy::pedantic)]`.
- `cargo test --workspace --all-features`: **218 / 218 passing** (184 unit + 16 integration + 18 doctests). +14 net new unit tests covering the v0.0.6 surface.
- `RUSTDOCFLAGS="-D warnings -D rustdoc::broken_intra_doc_links -D rustdoc::missing_crate_level_docs -D rustdoc::invalid_codeblock_attributes -D rustdoc::invalid_html_tags -D rustdoc::bare_urls" cargo doc`: clean.
- `cargo +nightly rustdoc -- -Z unstable-options --show-coverage`: **281 / 281 public items documented — 100.0% coverage**. `#![deny(missing_docs)]` enforces this on every build.
- `#![forbid(unsafe_code)]` enforced at the crate root.

---

## Commits

| SHA | Subject |
| :--- | :--- |
| `3915faa` | fix: context-prefixed validation errors + relative item links (#34) |
| `905f254` | style(tests): fix rustfmt drift in property_tests regression block |
| `aeffff3` | chore(deps): bump time from 0.3.49 to 0.3.51 |
| `0910c8e` | feat(atom): add Atom 1.0 feed generation, validation, format detection (closes #24) |
| `a694d83` | docs(readme): full review against noyalib reference style + cloudcdn.pro logo swap |
| `dc62cd8` | fix(v0.0.6): close 5 spec/correctness bugs + drop dead deps |
| `37510bc` | ci(docs): migrate docs publish to GitHub Pages workflow mode |

---

## Public API breaks (acceptable in 0.0.x)

- `RssError::ValidationErrors(Vec<String>)` → `RssError::ValidationErrors(Vec<ValidationError>)`. Migration: replace `errors.iter().any(|e| e == "channel.title is missing")` with `errors.iter().any(|e| e.field == "channel.title")` for structured access, or with `errors.iter().any(|e| e.to_string() == "channel.title is missing")` for string-compatible access.
- `data::parse_date` and `RssItem::pub_date_parsed` now return `time::OffsetDateTime` instead of `dtt::DateTime`. Migration: callers that only checked `is_ok()` are unaffected; callers that read fields out of the returned value need to migrate to `time` accessors.
- `Cargo.toml`: removed `dtt`, `commons` (euxis-commons), and `serde_json` from `[dependencies]`. Removed the no-op `async = []` feature flag.

---

## Test plan

- [x] `cargo test --workspace --all-features` — 218 / 218 pass locally
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Strict `cargo doc` with extra rustdoc lints — clean
- [x] `cargo +nightly rustdoc -- --show-coverage` — 281 / 281 (100.0%)
- [x] `cargo run --release --example stress_huge_feed` — 15 ms / 114 ms / 7 µs against a < 1 s budget
- [x] All three new examples (`example_atom`, `example_detect`, `example_validation_errors`) smoke-run cleanly
- [ ] CI full run on this PR
- [ ] Live docs at https://doc.rssgen.co republished from the workflow after merge