### PR TITLE
chore(deps): consolidate dependency updates for v0.0.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         with:
           key: llvm-cov
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2
         with:
           tool: cargo-llvm-cov
       - name: cargo llvm-cov

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -37,7 +37,7 @@ jobs:
           key: sbom
           save-if: false
 
-      - uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2
         with:
           tool: cargo-cyclonedx
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -44,6 +44,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF to code-scanning dashboard
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v3
         with:
           sarif_file: results.sarif

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rss-gen"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "arbitrary",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 # General project metadata
 name = "rss-gen"                            # The name of the library
-version = "0.0.8"
+version = "0.0.9"
 authors = ["RSS Generator Contributors"]    # Library contributors
 edition = "2021"                            # Rust edition being used
 rust-version = "1.88.0"                     # Minimum supported Rust version. Bumped from 1.79.0 in v0.0.6: `time 0.3.51` / `time-core 0.1.9` declare `rust-version = "1.88"` and the `icu_*` chain (via `url`/`idna`) pulls 1.86. Effective floor through current crates.io is 1.88.

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,11 @@
+# `clippy::cargo` is denied in src/lib.rs, which turns on
+# `multiple_crate_versions`. `syn` is currently duplicated across the
+# ecosystem: `serde_derive` and `thiserror-impl` have moved to syn 3,
+# while `derive_arbitrary`, `displaydoc`, `quickcheck_macros`,
+# `synstructure`, `yoke-derive` and `zerocopy-derive` still require
+# syn 2. Nothing in this crate can unify them — it resolves when those
+# proc-macro crates finish migrating.
+#
+# Allow the duplicate for `syn` specifically rather than switching off
+# the whole lint, so a genuinely avoidable duplication still fails CI.
+allowed-duplicate-crates = ["syn"]


### PR DESCRIPTION
Consolidates the open Dependabot PRs into a single release branch and bumps the version to `0.0.9`.

### Superseded updates

| PR | Update |
|----|--------|
| #50 | chore(deps): bump the github-actions group with 2 updates |

### Verification

- `cargo fmt --all --check` clean ✅
- `cargo clippy --all-targets --all-features -- -D warnings` clean ✅ (**was failing on `main`**)
- `cargo test` — 0 failures ✅

**Pre-existing clippy failure fixed.** `src/lib.rs` denies `clippy::cargo`, which enables `multiple_crate_versions`, and `syn` currently resolves to both 2.0.118 and 3.0.3: `serde_derive` and `thiserror-impl` have moved to syn 3 while `derive_arbitrary`, `displaydoc`, `quickcheck_macros`, `synstructure`, `yoke-derive` and `zerocopy-derive` still need syn 2. Nothing in this crate can unify them. Added a `clippy.toml` allowing the duplicate for `syn` **only**, so a genuinely avoidable duplication would still fail the gate.
