### PR TITLE
chore: release v0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `rss-gen` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.9](https://github.com/sebastienrousseau/rssgen/compare/v0.0.8...v0.0.9) - 2026-08-05
+
+### Dependencies
+
+- *(deps)* consolidate dependency updates for v0.0.9 ([#51](https://github.com/sebastienrousseau/rssgen/pull/51))
+
 ## [0.0.8] - 2026-07-24
 
 ## [0.0.6](https://github.com/sebastienrousseau/rssgen/compare/v0.0.5...v0.0.6) - 2026-06-28


### PR DESCRIPTION



## 🤖 New release

* `rss-gen`: 0.0.8 -> 0.0.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.9](https://github.com/sebastienrousseau/rssgen/compare/v0.0.8...v0.0.9) - 2026-08-05

### Dependencies

- *(deps)* consolidate dependency updates for v0.0.9 ([#51](https://github.com/sebastienrousseau/rssgen/pull/51))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).