### PR TITLE
chore: release v0.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rss-gen"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "arbitrary",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 # General project metadata
 name = "rss-gen"                            # The name of the library
-version = "0.0.9"
+version = "0.0.10"
 authors = ["RSS Generator Contributors"]    # Library contributors
 edition = "2021"                            # Rust edition being used
 rust-version = "1.88.0"                     # Minimum supported Rust version. Bumped from 1.79.0 in v0.0.6: `time 0.3.51` / `time-core 0.1.9` declare `rust-version = "1.88"` and the `icu_*` chain (via `url`/`idna`) pulls 1.86. Effective floor through current crates.io is 1.88.


### PR DESCRIPTION



## 🤖 New release

* `rss-gen`: 0.0.9 -> 0.0.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.9](https://github.com/sebastienrousseau/rssgen/compare/v0.0.8...v0.0.9) - 2026-08-05

### Dependencies

- *(deps)* consolidate dependency updates for v0.0.9 ([#51](https://github.com/sebastienrousseau/rssgen/pull/51))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).