### PR TITLE
chore(deps): consolidate dependency updates for v0.0.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,10 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
           show-progress: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: '1.88.0'
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           key: msrv
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -114,11 +114,11 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
           show-progress: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: nightly
           components: miri
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           key: miri
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -147,15 +147,15 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
           show-progress: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: stable
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           key: llvm-cov
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2
+      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2
         with:
           tool: cargo-llvm-cov
       - name: cargo llvm-cov

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: stable
       - name: Run release-plz release
@@ -59,7 +59,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: stable
       - name: Run release-plz release-pr

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -28,16 +28,16 @@ jobs:
           persist-credentials: false
           show-progress: false
 
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           key: sbom
           save-if: false
 
-      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2
+      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2
         with:
           tool: cargo-cyclonedx
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -44,6 +44,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF to code-scanning dashboard
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v3
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to `rss-gen` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.11](https://github.com/sebastienrousseau/rssgen/compare/v0.0.10...v0.0.11) - 2026-08-10
+
+### Dependencies
+
+- *(deps)* `time` 0.3.54 -> 0.3.55 in the minor-and-patch group ([#55](https://github.com/sebastienrousseau/rssgen/pull/55))
+- *(ci)* `dtolnay/rust-toolchain`, `Swatinem/rust-cache` v2.9.1 -> v2.9.2,
+  `taiki-e/install-action`, and `github/codeql-action/upload-sarif`
+  v4.37.4 -> v4.37.6 ([#54](https://github.com/sebastienrousseau/rssgen/pull/54))
+
+## [0.0.10](https://github.com/sebastienrousseau/rssgen/compare/v0.0.9...v0.0.10) - 2026-08-08
+
+Version-only release; no source or dependency changes. Recorded here
+because the release shipped to crates.io without a changelog entry.
+
 ## [0.0.9](https://github.com/sebastienrousseau/rssgen/compare/v0.0.8...v0.0.9) - 2026-08-05
 
 ### Dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rss-gen"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "arbitrary",
  "criterion",
@@ -1015,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 # General project metadata
 name = "rss-gen"                            # The name of the library
-version = "0.0.10"
+version = "0.0.11"
 authors = ["RSS Generator Contributors"]    # Library contributors
 edition = "2021"                            # Rust edition being used
 rust-version = "1.88.0"                     # Minimum supported Rust version. Bumped from 1.79.0 in v0.0.6: `time 0.3.51` / `time-core 0.1.9` declare `rust-version = "1.88"` and the `icu_*` chain (via `url`/`idna`) pulls 1.86. Effective floor through current crates.io is 1.88.


### PR DESCRIPTION
Supersedes #54, #55.

- `time` 0.3.54 -> 0.3.55 in the minor-and-patch group (#55)
- `dtolnay/rust-toolchain` `2c7215f1` -> `6c977a6c` (6 call sites)
- `Swatinem/rust-cache` v2.9.1 -> v2.9.2 (4 call sites)
- `taiki-e/install-action` `6a1bd70e` -> `6c6fd71f` (2 call sites)
- `github/codeql-action/upload-sarif` `f205ea1c` -> `5595ccaf`
- version 0.0.10 -> 0.0.11

No `feat/*` branch exists, so the 0.0.1 bump applies.

### Corrected a stale pin annotation

The codeql-action line was annotated `# v3` while pinned to `f205ea1c`, which is **v4.37.4** — and Dependabot carried that stale `# v3` straight onto the new SHA. Annotated `# v4.37.6`, matching what `5595ccaf` actually is. Same defect as sebastienrousseau/cloudcdn.pro#154.

### CHANGELOG

Added the 0.0.11 entry, plus the **missing 0.0.10 entry** — that release shipped to crates.io on 2026-08-08 without one. Comparing `v0.0.9...v0.0.10` shows only release-plz bookkeeping commits, so it is recorded as a version-only release rather than given invented content.

### Verification

- `cargo check --locked`: exit 0
- `cargo test --all-features`: **218 passed, 0 failed**
- no superseded action SHA remains anywhere under `.github/`